### PR TITLE
Separation of Lexer interface and implementation

### DIFF
--- a/lexer.py
+++ b/lexer.py
@@ -185,7 +185,7 @@ class _LexerBuilder:
 
         new_lexer.bol = self.bol
         new_lexer.level = self.level
-        return newLexer
+        return new_lexer
 
     def skip(self, value=1):
         """Skip 'value' characters in the input string."""

--- a/lexer.py
+++ b/lexer.py
@@ -192,27 +192,26 @@ class _LexerBuilder:
 
     # == ERROR REPORTING ==
 
-    # TODO: Make error style more gcc-like
     def error_out(self, message, lineno=None, lexpos=None):
         """Signal lexing error."""
         if lineno is not None:
             if lexpos is not None:
-                s = "%d:%d Error: %s" % (lineno, lexpos, message)
+                s = "%d:%d error: %s" % (lineno, lexpos, message)
             else:
-                s = "%d: Error: %s" % (lineno, message)
+                s = "%d: error: %s" % (lineno, message)
         else:
-            s = "Error: %s" % (message)
+            s = "error: %s" % (message)
         err.push_error(lineno or 0, s)
 
     def warning_out(self, message, lineno=None, lexpos=None):
         """Signal lexing warning."""
         if lineno is not None:
             if lexpos is not None:
-                s = "%s: %d:%d Warning: %s" % (lineno, lexpos, message)
+                s = "%s: %d:%d warning: %s" % (lineno, lexpos, message)
             else:
-                s = "%s: %d: Warning: %s" % (lineno, message)
+                s = "%s: %d: warning: %s" % (lineno, message)
         else:
-            s = "%s: Warning: %s" % (message)
+            s = "%s: warning: %s" % (message)
         err.push_warning(lineno or 0, s)
 
     # == LEXING OF NON-TOKENS ==
@@ -414,12 +413,14 @@ class Lexer:
     _lexer = None
 
     # == REQUIRED METHODS (see __LexerBuilder for details) ==
+
     token = None
     input = None
     clone = None
     skip = None
 
     # == EXPORT PLY ATTRIBUTES ==
+
     # NOTE: These poke deep inside the _LexerBuilder code...
     @property
     def lexdata(self):
@@ -469,6 +470,7 @@ class Lexer:
         self.skip  = self._lexer.skip
 
     # == ITERATOR INTERFACE ==
+
     def __iter__(self):
         return self
 

--- a/lexer.py
+++ b/lexer.py
@@ -155,8 +155,8 @@ class LlamaLexer:
         if self.lexer:
             self.lexer.lineno = value
 
-    # If debug is True, token will be duplicated to stdout.
-    debug = False
+    # If verbose is True, token will be duplicated to stdout.
+    verbose = False
 
     # File position of the most recent beginning of line
     bol = 0
@@ -164,12 +164,12 @@ class LlamaLexer:
     # Levels of nested comment blocks still open
     level = 0
 
-    def __init__(self, debug=False):
+    def __init__(self, verbose=False):
         """
         Initialize wrapper object of PLY lexer. To get a working LlamaLexer,
         invoke build() on the returned object.
         """
-        self.debug = debug
+        self.verbose = verbose
 
     # == ERROR PROCESSING ==
 
@@ -236,7 +236,7 @@ class LlamaLexer:
 
         # Track the token's position in the current column.
         t.lexpos = self.lexpos
-        if self.debug:
+        if self.verbose:
             print((t.type, t.value, t.lineno, t.lexpos))
         return t
 
@@ -246,7 +246,7 @@ class LlamaLexer:
 
     def clone(self):
         """Return a copy of the current lexer."""
-        newLexer = LlamaLexer(debug=self.debug)
+        newLexer = LlamaLexer(verbose=self.verbose)
         newLexer.lexer = self.lexer.clone()
 
         newLexer.bol = self.bol

--- a/main.py
+++ b/main.py
@@ -61,8 +61,8 @@ def mk_CLI_parser():
     )
 
     CLI_parser.add_argument(
-        '-ld',
-        '--lexer_debug',
+        '-lv',
+        '--lexer_verbose',
         help='''
             Output the lexed tokens along with their file position to stdout.
             Report any lexing errors to stderr.
@@ -117,12 +117,12 @@ def main():
     opts['input'] = args.input
     opts['output'] = args.output
     opts['prepare'] = args.prepare
-    opts['lexer_debug'] = args.lexer_debug
+    opts['lexer_verbose'] = args.lexer_verbose
     opts['parser_debug'] = args.parser_debug
 
     # Make a lexer. By default, the lexer is optimized and accepts
     # only ASCII input.
-    lexer = lex.LlamaLexer(debug=opts['lexer_debug'])
+    lexer = lex.LlamaLexer(verbose=opts['lexer_verbose'])
     lexer.build(
         lextab='lextab',
         optimize=1,

--- a/main.py
+++ b/main.py
@@ -16,7 +16,7 @@ import error as err
 import lexer as lex
 import parser as prs
 
-# Compiler invokation options and switches.
+# Compiler invocation options and switches.
 # Available to all modules.
 opts = collections.defaultdict(lambda: None)
 
@@ -120,13 +120,14 @@ def main():
     opts['lexer_verbose'] = args.lexer_verbose
     opts['parser_debug'] = args.parser_debug
 
-    # Make a lexer. By default, the lexer is optimized and accepts
-    # only ASCII input.
-    lexer = lex.LlamaLexer(verbose=opts['lexer_verbose'])
-    lexer.build(
+    # Make a lexer. By default, the lexer accepts only ASCII
+    # and is optimized (i.e caches the lexing tables across
+    # invocations).
+    lexer = lex.Lexer(
         lextab='lextab',
         optimize=1,
-        reflags=re.ASCII)
+        reflags=re.ASCII,
+        verbose=opts['lexer_verbose'])
 
     # Make a parser.
     parser = prs.LlamaParser()


### PR DESCRIPTION
I splitted class LlamaLexer into classes Lexer (interface) and _LexerBuilder (implementation). It is now possible to construct a complete lexer for llama with one call to Lexer (see main.py).

Issues:
1) The lexer returned from _LexerBuilder is somewhat incomplete; it doesn't conform to the PLY interface.
2) The Lexer class is tightly coupled with the _LexerBuilder class.

Both of these issues can be fixed by making _LexerBuilder produce lexers conforming to the PLY interface. This is not hard; just add the appropriate "@property" decorators to the _LexerBuilder class. However, since Lexer class does that already, there will be some inevitable code duplicaton.
