### PR TITLE
[WIP] Refactor and expand Symbol Table. Seperate ConstantDef from FunctionDef.

### DIFF
--- a/ast.py
+++ b/ast.py
@@ -156,6 +156,12 @@ class VariableDef(Def):
         self.name = name
         self.type = type
 
+class ConstantDef(Def):
+    def __init__(self, name, body, type=None):
+        self.name = name
+        self.body = body
+        self.type = type
+
 class ArrayVariableDef(VariableDef):
     def __init__(self, name, dimensions, itemType=None):
         self.name = name

--- a/parser.py
+++ b/parser.py
@@ -73,21 +73,22 @@ class Parser:
 
     def p_def(self, p):
         """def : function_def
+               | constant_def
                | variable_def"""
         p[0] = p[1]
 
     def p_function_def(self, p):
-        """function_def : GENID param_list COLON type EQ expr
-                        | GENID param_list EQ expr"""
+        """function_def : GENID param_seq COLON type EQ expr
+                        | GENID param_seq EQ expr"""
         if len(p) == 7:
             p[0] = ast.FunctionDef(p[1], p[2], p[6], p[4])
         else:
             p[0] = ast.FunctionDef(p[1], p[2], p[4])
 
-    def p_param_list(self, p):
-        """param_list : param param_list
-                      | empty"""
-        self._expand_list(p)
+    def p_param_seq(self, p):
+        """param_seq : param param_seq
+                     | param"""
+        self._expand_seq(p, 1, 2)
 
     def p_param(self, p):
         """param : LPAREN GENID COLON type RPAREN
@@ -399,6 +400,14 @@ class Parser:
     def p_while_expr(self, p):
         """while_expr : WHILE expr DO expr DONE"""
         p[0] = ast.WhileExpression(p[2], p[4])
+
+    def p_constant_def(self, p):
+        """constant_def : GENID COLON type EQ expr
+                        | GENID EQ expr"""
+        if len(p) == 6:
+            p[0] = ast.ConstantDef(p[1], p[5], p[3])
+        else:
+            p[0] = ast.ConstantDef(p[1], p[3])
 
     def p_variable_def(self, p):
         """variable_def : array_variable_def

--- a/symbol.py
+++ b/symbol.py
@@ -161,7 +161,7 @@ class SymbolTable:
 
         return entry
 
-    def insert_symbol(self, identifier, guard=False):
+    def _insert_entry(self, new_entry, guard=False):
         """
         Insert a new symbol in the current scope.
         If 'guard' is True, alert if an alias is already present.
@@ -169,19 +169,18 @@ class SymbolTable:
         assert self.cur_scope, 'No scope to insert into.'
 
         if guard:
-            entry = self._find_identifier_in_current_scope(identifier)
+            entry = self._find_identifier_in_current_scope(new_entry.identifier)
 
             if entry is not None:
                 self._logger.error(
                     # FIXME: Meaningful line?
-                    "Duplicate identifier: %s" % identifier
+                    "Duplicate identifier: %s" % new_entry.identifier
                     # TODO: Show line of previous declaration
                 )
 
                 return entry
 
-        new_entry = Entry(identifier=identifier, scope=self.cur_scope)
-        self.hash_table[identifier].append(new_entry)
+        self.hash_table[new_entry.identifier].append(new_entry)
         self.cur_scope.entries.append(new_entry)
 
         return new_entry

--- a/symbol.py
+++ b/symbol.py
@@ -28,6 +28,10 @@ class Entry:
         self.type = type
         # TODO: Initialize lineno and lexpos
 
+class Variable(Entry):
+    def __init__(self, vdef, scope):
+        super().__init__(vdef.name, vdef.type, scope)
+
 
 class Scope:
     """
@@ -183,4 +187,7 @@ class SymbolTable:
         self.hash_table[new_entry.identifier].append(new_entry)
         self.cur_scope.entries.append(new_entry)
 
+    def new_variable(self, vdef, guard):
+        new_entry = Variable(vdef, self.cur_scope)
+        self._insert_entry(new_entry, guard)
         return new_entry

--- a/symbol.py
+++ b/symbol.py
@@ -17,13 +17,15 @@ class Entry:
     """An entry of the symbol table. It knows which scope it's in."""
     identifier = None
     scope = None
+    type  = None
 
     lexpos = None
     lineno = None
 
-    def __init__(self, identifier, scope):
+    def __init__(self, identifier, type, scope):
         self.identifier = identifier
         self.scope = scope
+        self.type = type
         # TODO: Initialize lineno and lexpos
 
 
@@ -74,7 +76,8 @@ class SymbolTable:
         )
 
         for identifier in lib_namespace:
-            entry = Entry(identifier, lib_scope)
+            # FIXME: Add types for library functions
+            entry = Entry(identifier, None, lib_scope)
             lib_scope.entries.append(entry)
 
         self._push_scope(lib_scope)

--- a/symbol.py
+++ b/symbol.py
@@ -32,6 +32,10 @@ class Variable(Entry):
     def __init__(self, vdef, scope):
         super().__init__(vdef.name, vdef.type, scope)
 
+class Constant(Entry):
+    def __init__(self, constdef, scope):
+        super().__init__(constdef.name, constdef.type, scope)
+        self.value = constdef.value
 
 class Scope:
     """
@@ -191,3 +195,9 @@ class SymbolTable:
         new_entry = Variable(vdef, self.cur_scope)
         self._insert_entry(new_entry, guard)
         return new_entry
+
+    def new_constant(self, constdef, guard):
+        new_entry = Constant(constdef, self.cur_scope)
+        self._insert_entry(new_entry, guard)
+        return new_entry
+


### PR DESCRIPTION
### Parser:
- Separate definitions of constants from definitions of functions. 
### Symbol:
- Add `type` to entries.
- Add `Constant` and `Variable` classes for creating specific types of entries.
- Separate entry creation from entry insertion; the former is done via public methods, the latter via private ones.
- Delegate error string formatting to `error` module.
- Make `logger` public.
