### PR TITLE
Add line tracking to parser. Add line info to errors of type module.

### DIFF
--- a/compiler/ast.py
+++ b/compiler/ast.py
@@ -11,8 +11,20 @@
 from compiler import type
 
 class Node:
+    lineno = None
+    lexpos = None
+
     def __init__(self):
         raise NotImplementedError
+
+    def set_pos(self, lineno, lexpos=None):
+        if lexpos is None:  # initialization with other object
+            obj = lineno
+            self.lineno = obj.lineno
+            self.lexpos = obj.lexpos
+        else:  # normal initialization
+            self.lineno = lineno
+            self.lexpos = lexpos
 
 class ListNode(Node):
     list = None

--- a/compiler/ast.py
+++ b/compiler/ast.py
@@ -17,14 +17,10 @@ class Node:
     def __init__(self):
         raise NotImplementedError
 
-    def set_pos(self, lineno, lexpos=None):
-        if lexpos is None:  # initialization with other object
-            obj = lineno
-            self.lineno = obj.lineno
-            self.lexpos = obj.lexpos
-        else:  # normal initialization
-            self.lineno = lineno
-            self.lexpos = lexpos
+    def copy_pos(self, node):
+        """Copy line info from another AST node."""
+        self.lineno = node.lineno
+        self.lexpos = node.lexpos
 
 class ListNode(Node):
     list = None

--- a/compiler/parse.py
+++ b/compiler/parse.py
@@ -16,6 +16,15 @@ from ply import yacc
 from compiler import ast, lex, type
 
 
+def _track(p):
+    if isinstance(p[1], (ast.Node, type.Type)):
+        if p[0] is not p[1]:
+            p[0].copy_pos(p[1])
+    else:
+        node = p[0]
+        node.lineno = p.lineno(1)
+        node.lexpos = p.lexpos(1)
+
 class Parser:
     """A parser for the Llama language"""
     precedence = (
@@ -49,7 +58,6 @@ class Parser:
     def p_program(self, p):
         """program : def_list"""
         p[0] = ast.Program(p[1])
-        p[0].lineno, p[0].lexpos = 1, 1  # By convention
 
     def p_def_list(self, p):
         """def_list : letdef def_list
@@ -64,7 +72,7 @@ class Parser:
             p[0] = ast.LetDef(p[3], isRec=True)
         else:
             p[0] = ast.LetDef(p[2])
-        self._track_first_token(p)
+        _track(p)
 
     def p_def_seq(self, p):
         """def_seq : def AND def_seq
@@ -75,6 +83,7 @@ class Parser:
         """def : function_def
                | variable_def"""
         p[0] = p[1]
+        _track(p)
 
     def p_function_def(self, p):
         """function_def : GENID param_list COLON type EQ expr
@@ -83,7 +92,7 @@ class Parser:
             p[0] = ast.FunctionDef(p[1], p[2], p[6], p[4])
         else:
             p[0] = ast.FunctionDef(p[1], p[2], p[4])
-        self._track_first_token(p)
+        _track(p)
 
     def p_param_list(self, p):
         """param_list : param param_list
@@ -97,7 +106,7 @@ class Parser:
             p[0] = ast.Param(p[2], p[4])
         else:
             p[0] = ast.Param(p[1])
-        self._track_first_token(p)
+        _track(p)
 
     def p_type(self, p):
         """type : LPAREN type RPAREN
@@ -107,6 +116,7 @@ class Parser:
             p[0] = p[2]
         else:
             p[0] = p[1]
+        _track(p)
 
     def p_builtin_type(self, p):
         """builtin_type : BOOL
@@ -115,7 +125,7 @@ class Parser:
                         | INT
                         | UNIT"""
         p[0] = type.builtin_map[p[1]]()
-        self._track_first_token(p)
+        _track(p)
 
     def p_derived_type(self, p):
         """derived_type : array_type
@@ -123,6 +133,7 @@ class Parser:
                         | ref_type
                         | user_type"""
         p[0] = p[1]
+        _track(p)
 
     def p_array_type(self, p):
         """array_type : ARRAY LBRACKET star_comma_seq RBRACKET OF type
@@ -131,7 +142,7 @@ class Parser:
             p[0] = type.Array(p[6], p[3])
         else:
             p[0] = type.Array(p[3])
-        self._track_first_token(p)
+        _track(p)
 
     def p_star_comma_seq(self, p):
         """star_comma_seq : TIMES COMMA star_comma_seq
@@ -145,17 +156,17 @@ class Parser:
     def p_function_type(self, p):
         """function_type : type ARROW type"""
         p[0] = type.Function(p[1], p[3])
-        self._track_first_node(p)
+        _track(p)
 
     def p_ref_type(self, p):
         """ref_type : type REF"""
         p[0] = type.Ref(p[1])
-        self._track_first_node(p)
+        _track(p)
 
     def p_user_type(self, p):
         """user_type : GENID"""
         p[0] = type.User(p[1])
-        self._track_first_token(p)
+        _track(p)
 
     def p_empty(self, p):
         """empty :"""
@@ -203,22 +214,21 @@ class Parser:
                 | while_expr"""
         if len(p) == 4:
             p[0] = ast.BinaryExpression(p[1], p[2], p[3])
-            self._track_first_node(p)
         elif len(p) == 3:
             p[0] = ast.UnaryExpression(p[1], p[2])
-            self._track_first_token(p)
         else:
             p[0] = p[1]
+        _track(p)
 
     def p_begin_end_expr(self, p):
         """begin_end_expr : BEGIN expr END"""
         p[0] = p[2]
-        self._track_first_token(p)
+        _track(p)
 
     def p_ccall_expr(self, p):
         """ccall_expr : CONID simple_expr_seq"""
         p[0] = ast.ConstructorCallExpression(p[1], p[2])
-        self._track_first_token(p)
+        _track(p)
 
     def p_simple_expr_seq(self, p):
         """simple_expr_seq : simple_expr simple_expr_seq
@@ -239,61 +249,60 @@ class Parser:
                        | uconst_simple_expr"""
         if len(p) == 5:
             p[0] = ast.ArrayExpression(p[1], p[3])
-            self._track_first_token(p)
         elif len(p) == 4:
             p[0] = p[2]
         elif len(p) == 3:
             # bang
             p[0] = ast.UnaryExpression(p[1], p[2])
-            self._track_first_token(p)
         else:
             p[0] = p[1]
+        _track(p)
 
     def p_bconst_simple_expr(self, p):
         """bconst_simple_expr : TRUE
                               | FALSE"""
         p[0] = ast.ConstExpression(type.Bool(), p[1])
-        self._track_first_token(p)
+        _track(p)
 
     def p_cconst_simple_expr(self, p):
         """cconst_simple_expr : CCONST"""
         p[0] = ast.ConstExpression(type.Char(), p[1])
-        self._track_first_token(p)
+        _track(p)
 
     def p_conid_simple_expr(self, p):
         """conid_simple_expr : CONID"""
         p[0] = ast.ConidExpression(p[1])
-        self._track_first_token(p)
+        _track(p)
 
     def p_iconst_simple_expr(self, p):
         """iconst_simple_expr : ICONST"""
         p[0] = ast.ConstExpression(type.Int(), p[1])
-        self._track_first_token(p)
+        _track(p)
 
     def p_fconst_simple_expr(self, p):
         """fconst_simple_expr : FCONST"""
         p[0] = ast.ConstExpression(type.Float(), p[1])
-        self._track_first_token(p)
+        _track(p)
 
     def p_genid_simple_expr(self, p):
         """genid_simple_expr : GENID"""
         p[0] = ast.GenidExpression(p[1])
-        self._track_first_token(p)
+        _track(p)
 
     def p_sconst_simple_expr(self, p):
         """sconst_simple_expr : SCONST"""
         p[0] = ast.ConstExpression(type.String(), p[1])
-        self._track_first_token(p)
+        _track(p)
 
     def p_uconst_simple_expr(self, p):
         """uconst_simple_expr : LPAREN RPAREN"""
         p[0] = ast.ConstExpression(type.Unit())
-        self._track_first_token(p)
+        _track(p)
 
     def p_delete_expr(self, p):
         """delete_expr : DELETE expr"""
         p[0] = ast.DeleteExpression(p[2])
-        self._track_first_token(p)
+        _track(p)
 
     def p_dim_expr(self, p):
         """dim_expr : DIM ICONST GENID
@@ -302,7 +311,7 @@ class Parser:
             p[0] = ast.DimExpression(p[3], p[2])
         else:
             p[0] = ast.DimExpression(p[2])
-        self._track_first_token(p)
+        _track(p)
 
     def p_for_expr(self, p):
         """for_expr : FOR GENID EQ expr DOWNTO expr DO expr DONE
@@ -311,17 +320,17 @@ class Parser:
             p[0] = ast.ForExpression(p[2], p[4], p[6], p[8])
         else:
             p[0] = ast.ForExpression(p[2], p[4], p[6], p[8], isDown=True)
-        self._track_first_token(p)
+        _track(p)
 
     def p_gcall_expr(self, p):
         """gcall_expr : GENID simple_expr_seq"""
         p[0] = ast.FunctionCallExpression(p[1], p[2])
-        self._track_first_token(p)
+        _track(p)
 
     def p_in_expr(self, p):
         """in_expr : letdef IN expr"""
         p[0] = ast.LetInExpression(p[1], p[3])
-        self._track_first_node(p)
+        _track(p)
 
     def p_if_expr(self, p):
         # WARNING: Changing order of clauses produces Syntax Errors,
@@ -332,12 +341,12 @@ class Parser:
             p[0] = ast.IfExpression(p[2], p[4], p[6])
         else:
             p[0] = ast.IfExpression(p[2], p[4])
-        self._track_first_token(p)
+        _track(p)
 
     def p_match_expr(self, p):
         """match_expr : MATCH expr WITH clause_seq END"""
         p[0] = ast.MatchExpression(p[2], p[4])
-        self._track_first_token(p)
+        _track(p)
 
     def p_clause_seq(self, p):
         """clause_seq : clause PIPE clause_seq
@@ -347,16 +356,16 @@ class Parser:
     def p_clause(self, p):
         """clause : pattern ARROW expr"""
         p[0] = ast.Clause(p[1], p[3])
-        self._track_first_node(p)
+        _track(p)
 
     def p_pattern(self, p):
         """pattern : CONID simple_pattern_list
                    | simple_pattern"""
         if len(p) == 3:
             p[0] = ast.Pattern(p[1], p[2])
-            self._track_first_token(p)
         else:
             p[0] = p[1]
+        _track(p)
 
     def p_simple_pattern_list(self, p):
         """simple_pattern_list : simple_pattern simple_pattern_list
@@ -376,17 +385,18 @@ class Parser:
             p[0] = p[2]
         else:
             p[0] = p[1]
+        _track(p)
 
     def p_bconst_simple_pattern(self, p):
         """bconst_simple_pattern : TRUE
                                  | FALSE"""
         p[0] = ast.ConstExpression(type.Bool(), p[1])
-        self._track_first_token(p)
+        _track(p)
 
     def p_cconst_simple_pattern(self, p):
         """cconst_simple_pattern : CCONST"""
         p[0] = ast.ConstExpression(type.Char(), p[1])
-        self._track_first_token(p)
+        _track(p)
 
     def p_fconst_simple_pattern(self, p):
         """fconst_simple_pattern : FPLUS FCONST
@@ -395,17 +405,17 @@ class Parser:
             p[0] = ast.ConstExpression(type.Float(), p[2])
         else:
             p[0] = ast.ConstExpression(type.Float(), p[1])
-        self._track_first_token(p)
+        _track(p)
 
     def p_mfconst_simple_pattern(self, p):
         """mfconst_simple_pattern : FMINUS FCONST"""
         p[0] = ast.ConstExpression(type.Float(), -p[2])
-        self._track_first_token(p)
+        _track(p)
 
     def p_genid_simple_pattern(self, p):
         """genid_simple_pattern : GENID"""
         p[0] = ast.GenidPattern(p[1])
-        self._track_first_token(p)
+        _track(p)
 
     def p_iconst_simple_pattern(self, p):
         """iconst_simple_pattern : PLUS ICONST
@@ -414,27 +424,28 @@ class Parser:
             p[0] = ast.ConstExpression(type.Int(), p[2])
         else:
             p[0] = ast.ConstExpression(type.Int(), p[1])
-        self._track_first_token(p)
+        _track(p)
 
     def p_miconst_simple_pattern(self, p):
         """miconst_simple_pattern : MINUS ICONST"""
         p[0] = ast.ConstExpression(type.Int(), -p[2])
-        self._track_first_token(p)
+        _track(p)
 
     def p_new_expr(self, p):
         """new_expr : NEW type"""
         p[0] = ast.NewExpression(p[2])
-        self._track_first_token(p)
+        _track(p)
 
     def p_while_expr(self, p):
         """while_expr : WHILE expr DO expr DONE"""
         p[0] = ast.WhileExpression(p[2], p[4])
-        self._track_first_token(p)
+        _track(p)
 
     def p_variable_def(self, p):
         """variable_def : array_variable_def
                         | simple_variable_def"""
         p[0] = p[1]
+        _track(p)
 
     def p_array_variable_def(self, p):
         """array_variable_def : MUTABLE GENID LBRACKET expr_comma_seq RBRACKET COLON type
@@ -443,7 +454,7 @@ class Parser:
             p[0] = ast.ArrayVariableDef(p[2], p[4], p[7])
         else:
             p[0] = ast.ArrayVariableDef(p[2], p[4])
-        self._track_first_token(p)
+        _track(p)
 
     def p_expr_comma_seq(self, p):
         """expr_comma_seq : expr COMMA expr_comma_seq
@@ -457,13 +468,13 @@ class Parser:
             p[0] = ast.VariableDef(p[2], p[4])
         else:
             p[0] = ast.VariableDef(p[2])
-        self._track_first_token(p)
+        _track(p)
 
     def p_typedef(self, p):
         """typedef : TYPE tdef_and_seq"""
         p[0] = ast.TypeDefList(p[2])
-        self._track_first_token(p)
         self.typeTable.process(p[0])
+        _track(p)
 
     def p_tdef_and_seq(self, p):
         """tdef_and_seq : tdef AND tdef_and_seq
@@ -473,7 +484,7 @@ class Parser:
     def p_tdef(self, p):
         """tdef : GENID EQ constr_pipe_seq"""
         p[0] = ast.TDef(p[1], p[3])
-        self._track_first_token(p)
+        _track(p)
 
     def p_constr_pipe_seq(self, p):
         """constr_pipe_seq : constr PIPE constr_pipe_seq
@@ -487,7 +498,7 @@ class Parser:
             p[0] = ast.Constructor(p[1], p[3])
         else:
             p[0] = ast.Constructor(p[1])
-        self._track_first_token(p)
+        _track(p)
 
     def p_type_seq(self, p):
         """type_seq : type type_seq
@@ -518,15 +529,6 @@ class Parser:
         else:
             p[2].insert(0, p[1])
             p[0] = p[2]
-
-    def _track_first_node(self, rule):
-        dst_node, src_node = rule[0], rule[1]
-        dst_node.copy_pos(src_node)
-
-    def _track_first_token(self, rule):
-        node = rule[0]
-        node.lineno = rule.lineno(1)
-        node.lexpos = rule.lexpos(1)
 
     parser = None
     tokens = lex.tokens

--- a/compiler/parse.py
+++ b/compiler/parse.py
@@ -145,12 +145,12 @@ class Parser:
     def p_function_type(self, p):
         """function_type : type ARROW type"""
         p[0] = type.Function(p[1], p[3])
-        p[0].set_pos(p[1])
+        self._track_first_node(p)
 
     def p_ref_type(self, p):
         """ref_type : type REF"""
         p[0] = type.Ref(p[1])
-        p[0].set_pos(p[1])
+        self._track_first_node(p)
 
     def p_user_type(self, p):
         """user_type : GENID"""
@@ -203,7 +203,7 @@ class Parser:
                 | while_expr"""
         if len(p) == 4:
             p[0] = ast.BinaryExpression(p[1], p[2], p[3])
-            p[0].set_pos(p[1])
+            self._track_first_node(p)
         elif len(p) == 3:
             p[0] = ast.UnaryExpression(p[1], p[2])
             self._track_first_token(p)
@@ -321,7 +321,7 @@ class Parser:
     def p_in_expr(self, p):
         """in_expr : letdef IN expr"""
         p[0] = ast.LetInExpression(p[1], p[3])
-        p[0].set_pos(p[1])
+        self._track_first_node(p)
 
     def p_if_expr(self, p):
         # WARNING: Changing order of clauses produces Syntax Errors,
@@ -347,7 +347,7 @@ class Parser:
     def p_clause(self, p):
         """clause : pattern ARROW expr"""
         p[0] = ast.Clause(p[1], p[3])
-        p[0].set_pos(p[1])
+        self._track_first_node(p)
 
     def p_pattern(self, p):
         """pattern : CONID simple_pattern_list
@@ -519,9 +519,14 @@ class Parser:
             p[2].insert(0, p[1])
             p[0] = p[2]
 
+    def _track_first_node(self, rule):
+        dst_node, src_node = rule[0], rule[1]
+        dst_node.copy_pos(src_node)
+
     def _track_first_token(self, rule):
         node = rule[0]
-        node.set_pos(rule.lineno(1), rule.lexpos(1))
+        node.lineno = rule.lineno(1)
+        node.lexpos = rule.lexpos(1)
 
     parser = None
     tokens = lex.tokens

--- a/compiler/parse.py
+++ b/compiler/parse.py
@@ -49,6 +49,7 @@ class Parser:
     def p_program(self, p):
         """program : def_list"""
         p[0] = ast.Program(p[1])
+        p[0].lineno, p[0].lexpos = 1, 1  # By convention
 
     def p_def_list(self, p):
         """def_list : letdef def_list
@@ -63,7 +64,7 @@ class Parser:
             p[0] = ast.LetDef(p[3], isRec=True)
         else:
             p[0] = ast.LetDef(p[2])
-        p[0].set_pos(p.lineno(1), p.lexpos(1))
+        self._track_first_token(p)
 
     def p_def_seq(self, p):
         """def_seq : def AND def_seq
@@ -82,7 +83,7 @@ class Parser:
             p[0] = ast.FunctionDef(p[1], p[2], p[6], p[4])
         else:
             p[0] = ast.FunctionDef(p[1], p[2], p[4])
-        p[0].set_pos(p.lineno(1), p.lexpos(1))
+        self._track_first_token(p)
 
     def p_param_list(self, p):
         """param_list : param param_list
@@ -96,7 +97,7 @@ class Parser:
             p[0] = ast.Param(p[2], p[4])
         else:
             p[0] = ast.Param(p[1])
-        p[0].set_pos(p.lineno(1), p.lexpos(1))
+        self._track_first_token(p)
 
     def p_type(self, p):
         """type : LPAREN type RPAREN
@@ -114,7 +115,7 @@ class Parser:
                         | INT
                         | UNIT"""
         p[0] = type.builtin_map[p[1]]()
-        p[0].set_pos(p.lineno(1), p.lexpos(1))
+        self._track_first_token(p)
 
     def p_derived_type(self, p):
         """derived_type : array_type
@@ -130,7 +131,7 @@ class Parser:
             p[0] = type.Array(p[6], p[3])
         else:
             p[0] = type.Array(p[3])
-        p[0].set_pos(p.lineno(1), p.lexpos(1))
+        self._track_first_token(p)
 
     def p_star_comma_seq(self, p):
         """star_comma_seq : TIMES COMMA star_comma_seq
@@ -154,7 +155,7 @@ class Parser:
     def p_user_type(self, p):
         """user_type : GENID"""
         p[0] = type.User(p[1])
-        p[0].set_pos(p.lineno(1), p.lexpos(1))
+        self._track_first_token(p)
 
     def p_empty(self, p):
         """empty :"""
@@ -205,19 +206,19 @@ class Parser:
             p[0].set_pos(p[1])
         elif len(p) == 3:
             p[0] = ast.UnaryExpression(p[1], p[2])
-            p[0].set_pos(p.lineno(1), p.lexpos(1))
+            self._track_first_token(p)
         else:
             p[0] = p[1]
 
     def p_begin_end_expr(self, p):
         """begin_end_expr : BEGIN expr END"""
         p[0] = p[2]
-        p[0].set_pos(p.lineno(1), p.lexpos(1))
+        self._track_first_token(p)
 
     def p_ccall_expr(self, p):
         """ccall_expr : CONID simple_expr_seq"""
         p[0] = ast.ConstructorCallExpression(p[1], p[2])
-        p[0].set_pos(p.lineno(1), p.lexpos(1))
+        self._track_first_token(p)
 
     def p_simple_expr_seq(self, p):
         """simple_expr_seq : simple_expr simple_expr_seq
@@ -238,13 +239,13 @@ class Parser:
                        | uconst_simple_expr"""
         if len(p) == 5:
             p[0] = ast.ArrayExpression(p[1], p[3])
-            p[0].set_pos(p.lineno(1), p.lexpos(1))
+            self._track_first_token(p)
         elif len(p) == 4:
             p[0] = p[2]
         elif len(p) == 3:
             # bang
             p[0] = ast.UnaryExpression(p[1], p[2])
-            p[0].set_pos(p.lineno(1), p.lexpos(1))
+            self._track_first_token(p)
         else:
             p[0] = p[1]
 
@@ -252,47 +253,47 @@ class Parser:
         """bconst_simple_expr : TRUE
                               | FALSE"""
         p[0] = ast.ConstExpression(type.Bool(), p[1])
-        p[0].set_pos(p.lineno(1), p.lexpos(1))
+        self._track_first_token(p)
 
     def p_cconst_simple_expr(self, p):
         """cconst_simple_expr : CCONST"""
         p[0] = ast.ConstExpression(type.Char(), p[1])
-        p[0].set_pos(p.lineno(1), p.lexpos(1))
+        self._track_first_token(p)
 
     def p_conid_simple_expr(self, p):
         """conid_simple_expr : CONID"""
         p[0] = ast.ConidExpression(p[1])
-        p[0].set_pos(p.lineno(1), p.lexpos(1))
+        self._track_first_token(p)
 
     def p_iconst_simple_expr(self, p):
         """iconst_simple_expr : ICONST"""
         p[0] = ast.ConstExpression(type.Int(), p[1])
-        p[0].set_pos(p.lineno(1), p.lexpos(1))
+        self._track_first_token(p)
 
     def p_fconst_simple_expr(self, p):
         """fconst_simple_expr : FCONST"""
         p[0] = ast.ConstExpression(type.Float(), p[1])
-        p[0].set_pos(p.lineno(1), p.lexpos(1))
+        self._track_first_token(p)
 
     def p_genid_simple_expr(self, p):
         """genid_simple_expr : GENID"""
         p[0] = ast.GenidExpression(p[1])
-        p[0].set_pos(p.lineno(1), p.lexpos(1))
+        self._track_first_token(p)
 
     def p_sconst_simple_expr(self, p):
         """sconst_simple_expr : SCONST"""
         p[0] = ast.ConstExpression(type.String(), p[1])
-        p[0].set_pos(p.lineno(1), p.lexpos(1))
+        self._track_first_token(p)
 
     def p_uconst_simple_expr(self, p):
         """uconst_simple_expr : LPAREN RPAREN"""
         p[0] = ast.ConstExpression(type.Unit())
-        p[0].set_pos(p.lineno(1), p.lexpos(1))
+        self._track_first_token(p)
 
     def p_delete_expr(self, p):
         """delete_expr : DELETE expr"""
         p[0] = ast.DeleteExpression(p[2])
-        p[0].set_pos(p.lineno(1), p.lexpos(1))
+        self._track_first_token(p)
 
     def p_dim_expr(self, p):
         """dim_expr : DIM ICONST GENID
@@ -301,7 +302,7 @@ class Parser:
             p[0] = ast.DimExpression(p[3], p[2])
         else:
             p[0] = ast.DimExpression(p[2])
-        p[0].set_pos(p.lineno(1), p.lexpos(1))
+        self._track_first_token(p)
 
     def p_for_expr(self, p):
         """for_expr : FOR GENID EQ expr DOWNTO expr DO expr DONE
@@ -310,12 +311,12 @@ class Parser:
             p[0] = ast.ForExpression(p[2], p[4], p[6], p[8])
         else:
             p[0] = ast.ForExpression(p[2], p[4], p[6], p[8], isDown=True)
-        p[0].set_pos(p.lineno(1), p.lexpos(1))
+        self._track_first_token(p)
 
     def p_gcall_expr(self, p):
         """gcall_expr : GENID simple_expr_seq"""
         p[0] = ast.FunctionCallExpression(p[1], p[2])
-        p[0].set_pos(p.lineno(1), p.lexpos(1))
+        self._track_first_token(p)
 
     def p_in_expr(self, p):
         """in_expr : letdef IN expr"""
@@ -331,12 +332,12 @@ class Parser:
             p[0] = ast.IfExpression(p[2], p[4], p[6])
         else:
             p[0] = ast.IfExpression(p[2], p[4])
-        p[0].set_pos(p.lineno(1), p.lexpos(1))
+        self._track_first_token(p)
 
     def p_match_expr(self, p):
         """match_expr : MATCH expr WITH clause_seq END"""
         p[0] = ast.MatchExpression(p[2], p[4])
-        p[0].set_pos(p.lineno(1), p.lexpos(1))
+        self._track_first_token(p)
 
     def p_clause_seq(self, p):
         """clause_seq : clause PIPE clause_seq
@@ -353,7 +354,7 @@ class Parser:
                    | simple_pattern"""
         if len(p) == 3:
             p[0] = ast.Pattern(p[1], p[2])
-            p[0].set_pos(p.lineno(1), p.lexpos(1))
+            self._track_first_token(p)
         else:
             p[0] = p[1]
 
@@ -380,12 +381,12 @@ class Parser:
         """bconst_simple_pattern : TRUE
                                  | FALSE"""
         p[0] = ast.ConstExpression(type.Bool(), p[1])
-        p[0].set_pos(p.lineno(1), p.lexpos(1))
+        self._track_first_token(p)
 
     def p_cconst_simple_pattern(self, p):
         """cconst_simple_pattern : CCONST"""
         p[0] = ast.ConstExpression(type.Char(), p[1])
-        p[0].set_pos(p.lineno(1), p.lexpos(1))
+        self._track_first_token(p)
 
     def p_fconst_simple_pattern(self, p):
         """fconst_simple_pattern : FPLUS FCONST
@@ -394,17 +395,17 @@ class Parser:
             p[0] = ast.ConstExpression(type.Float(), p[2])
         else:
             p[0] = ast.ConstExpression(type.Float(), p[1])
-        p[0].set_pos(p.lineno(1), p.lexpos(1))
+        self._track_first_token(p)
 
     def p_mfconst_simple_pattern(self, p):
         """mfconst_simple_pattern : FMINUS FCONST"""
         p[0] = ast.ConstExpression(type.Float(), -p[2])
-        p[0].set_pos(p.lineno(1), p.lexpos(1))
+        self._track_first_token(p)
 
     def p_genid_simple_pattern(self, p):
         """genid_simple_pattern : GENID"""
         p[0] = ast.GenidPattern(p[1])
-        p[0].set_pos(p.lineno(1), p.lexpos(1))
+        self._track_first_token(p)
 
     def p_iconst_simple_pattern(self, p):
         """iconst_simple_pattern : PLUS ICONST
@@ -413,22 +414,22 @@ class Parser:
             p[0] = ast.ConstExpression(type.Int(), p[2])
         else:
             p[0] = ast.ConstExpression(type.Int(), p[1])
-        p[0].set_pos(p.lineno(1), p.lexpos(1))
+        self._track_first_token(p)
 
     def p_miconst_simple_pattern(self, p):
         """miconst_simple_pattern : MINUS ICONST"""
         p[0] = ast.ConstExpression(type.Int(), -p[2])
-        p[0].set_pos(p.lineno(1), p.lexpos(1))
+        self._track_first_token(p)
 
     def p_new_expr(self, p):
         """new_expr : NEW type"""
         p[0] = ast.NewExpression(p[2])
-        p[0].set_pos(p.lineno(1), p.lexpos(1))
+        self._track_first_token(p)
 
     def p_while_expr(self, p):
         """while_expr : WHILE expr DO expr DONE"""
         p[0] = ast.WhileExpression(p[2], p[4])
-        p[0].set_pos(p.lineno(1), p.lexpos(1))
+        self._track_first_token(p)
 
     def p_variable_def(self, p):
         """variable_def : array_variable_def
@@ -442,7 +443,7 @@ class Parser:
             p[0] = ast.ArrayVariableDef(p[2], p[4], p[7])
         else:
             p[0] = ast.ArrayVariableDef(p[2], p[4])
-        p[0].set_pos(p.lineno(1), p.lexpos(1))
+        self._track_first_token(p)
 
     def p_expr_comma_seq(self, p):
         """expr_comma_seq : expr COMMA expr_comma_seq
@@ -456,12 +457,12 @@ class Parser:
             p[0] = ast.VariableDef(p[2], p[4])
         else:
             p[0] = ast.VariableDef(p[2])
-        p[0].set_pos(p.lineno(1), p.lexpos(1))
+        self._track_first_token(p)
 
     def p_typedef(self, p):
         """typedef : TYPE tdef_and_seq"""
         p[0] = ast.TypeDefList(p[2])
-        p[0].set_pos(p.lineno(1), p.lexpos(1))
+        self._track_first_token(p)
         self.typeTable.process(p[0])
 
     def p_tdef_and_seq(self, p):
@@ -472,7 +473,7 @@ class Parser:
     def p_tdef(self, p):
         """tdef : GENID EQ constr_pipe_seq"""
         p[0] = ast.TDef(p[1], p[3])
-        p[0].set_pos(p.lineno(1), p.lexpos(1))
+        self._track_first_token(p)
 
     def p_constr_pipe_seq(self, p):
         """constr_pipe_seq : constr PIPE constr_pipe_seq
@@ -486,7 +487,7 @@ class Parser:
             p[0] = ast.Constructor(p[1], p[3])
         else:
             p[0] = ast.Constructor(p[1])
-        p[0].set_pos(p.lineno(1), p.lexpos(1))
+        self._track_first_token(p)
 
     def p_type_seq(self, p):
         """type_seq : type type_seq
@@ -517,6 +518,10 @@ class Parser:
         else:
             p[2].insert(0, p[1])
             p[0] = p[2]
+
+    def _track_first_token(self, rule):
+        node = rule[0]
+        node.set_pos(rule.lineno(1), rule.lexpos(1))
 
     parser = None
     tokens = lex.tokens

--- a/compiler/parse.py
+++ b/compiler/parse.py
@@ -63,6 +63,7 @@ class Parser:
             p[0] = ast.LetDef(p[3], isRec=True)
         else:
             p[0] = ast.LetDef(p[2])
+        p[0].set_pos(p.lineno(1), p.lexpos(1))
 
     def p_def_seq(self, p):
         """def_seq : def AND def_seq
@@ -81,6 +82,7 @@ class Parser:
             p[0] = ast.FunctionDef(p[1], p[2], p[6], p[4])
         else:
             p[0] = ast.FunctionDef(p[1], p[2], p[4])
+        p[0].set_pos(p.lineno(1), p.lexpos(1))
 
     def p_param_list(self, p):
         """param_list : param param_list
@@ -94,6 +96,7 @@ class Parser:
             p[0] = ast.Param(p[2], p[4])
         else:
             p[0] = ast.Param(p[1])
+        p[0].set_pos(p.lineno(1), p.lexpos(1))
 
     def p_type(self, p):
         """type : LPAREN type RPAREN
@@ -111,6 +114,7 @@ class Parser:
                         | INT
                         | UNIT"""
         p[0] = type.builtin_map[p[1]]()
+        p[0].set_pos(p.lineno(1), p.lexpos(1))
 
     def p_derived_type(self, p):
         """derived_type : array_type
@@ -126,6 +130,7 @@ class Parser:
             p[0] = type.Array(p[6], p[3])
         else:
             p[0] = type.Array(p[3])
+        p[0].set_pos(p.lineno(1), p.lexpos(1))
 
     def p_star_comma_seq(self, p):
         """star_comma_seq : TIMES COMMA star_comma_seq
@@ -139,14 +144,17 @@ class Parser:
     def p_function_type(self, p):
         """function_type : type ARROW type"""
         p[0] = type.Function(p[1], p[3])
+        p[0].set_pos(p[1])
 
     def p_ref_type(self, p):
         """ref_type : type REF"""
         p[0] = type.Ref(p[1])
+        p[0].set_pos(p[1])
 
     def p_user_type(self, p):
         """user_type : GENID"""
         p[0] = type.User(p[1])
+        p[0].set_pos(p.lineno(1), p.lexpos(1))
 
     def p_empty(self, p):
         """empty :"""
@@ -194,18 +202,22 @@ class Parser:
                 | while_expr"""
         if len(p) == 4:
             p[0] = ast.BinaryExpression(p[1], p[2], p[3])
+            p[0].set_pos(p[1])
         elif len(p) == 3:
             p[0] = ast.UnaryExpression(p[1], p[2])
+            p[0].set_pos(p.lineno(1), p.lexpos(1))
         else:
             p[0] = p[1]
 
     def p_begin_end_expr(self, p):
         """begin_end_expr : BEGIN expr END"""
         p[0] = p[2]
+        p[0].set_pos(p.lineno(1), p.lexpos(1))
 
     def p_ccall_expr(self, p):
         """ccall_expr : CONID simple_expr_seq"""
         p[0] = ast.ConstructorCallExpression(p[1], p[2])
+        p[0].set_pos(p.lineno(1), p.lexpos(1))
 
     def p_simple_expr_seq(self, p):
         """simple_expr_seq : simple_expr simple_expr_seq
@@ -226,11 +238,13 @@ class Parser:
                        | uconst_simple_expr"""
         if len(p) == 5:
             p[0] = ast.ArrayExpression(p[1], p[3])
+            p[0].set_pos(p.lineno(1), p.lexpos(1))
         elif len(p) == 4:
             p[0] = p[2]
         elif len(p) == 3:
             # bang
             p[0] = ast.UnaryExpression(p[1], p[2])
+            p[0].set_pos(p.lineno(1), p.lexpos(1))
         else:
             p[0] = p[1]
 
@@ -238,38 +252,47 @@ class Parser:
         """bconst_simple_expr : TRUE
                               | FALSE"""
         p[0] = ast.ConstExpression(type.Bool(), p[1])
+        p[0].set_pos(p.lineno(1), p.lexpos(1))
 
     def p_cconst_simple_expr(self, p):
         """cconst_simple_expr : CCONST"""
         p[0] = ast.ConstExpression(type.Char(), p[1])
+        p[0].set_pos(p.lineno(1), p.lexpos(1))
 
     def p_conid_simple_expr(self, p):
         """conid_simple_expr : CONID"""
         p[0] = ast.ConidExpression(p[1])
+        p[0].set_pos(p.lineno(1), p.lexpos(1))
 
     def p_iconst_simple_expr(self, p):
         """iconst_simple_expr : ICONST"""
         p[0] = ast.ConstExpression(type.Int(), p[1])
+        p[0].set_pos(p.lineno(1), p.lexpos(1))
 
     def p_fconst_simple_expr(self, p):
         """fconst_simple_expr : FCONST"""
         p[0] = ast.ConstExpression(type.Float(), p[1])
+        p[0].set_pos(p.lineno(1), p.lexpos(1))
 
     def p_genid_simple_expr(self, p):
         """genid_simple_expr : GENID"""
         p[0] = ast.GenidExpression(p[1])
+        p[0].set_pos(p.lineno(1), p.lexpos(1))
 
     def p_sconst_simple_expr(self, p):
         """sconst_simple_expr : SCONST"""
         p[0] = ast.ConstExpression(type.String(), p[1])
+        p[0].set_pos(p.lineno(1), p.lexpos(1))
 
     def p_uconst_simple_expr(self, p):
         """uconst_simple_expr : LPAREN RPAREN"""
         p[0] = ast.ConstExpression(type.Unit())
+        p[0].set_pos(p.lineno(1), p.lexpos(1))
 
     def p_delete_expr(self, p):
         """delete_expr : DELETE expr"""
         p[0] = ast.DeleteExpression(p[2])
+        p[0].set_pos(p.lineno(1), p.lexpos(1))
 
     def p_dim_expr(self, p):
         """dim_expr : DIM ICONST GENID
@@ -278,6 +301,7 @@ class Parser:
             p[0] = ast.DimExpression(p[3], p[2])
         else:
             p[0] = ast.DimExpression(p[2])
+        p[0].set_pos(p.lineno(1), p.lexpos(1))
 
     def p_for_expr(self, p):
         """for_expr : FOR GENID EQ expr DOWNTO expr DO expr DONE
@@ -286,14 +310,17 @@ class Parser:
             p[0] = ast.ForExpression(p[2], p[4], p[6], p[8])
         else:
             p[0] = ast.ForExpression(p[2], p[4], p[6], p[8], isDown=True)
+        p[0].set_pos(p.lineno(1), p.lexpos(1))
 
     def p_gcall_expr(self, p):
         """gcall_expr : GENID simple_expr_seq"""
         p[0] = ast.FunctionCallExpression(p[1], p[2])
+        p[0].set_pos(p.lineno(1), p.lexpos(1))
 
     def p_in_expr(self, p):
         """in_expr : letdef IN expr"""
         p[0] = ast.LetInExpression(p[1], p[3])
+        p[0].set_pos(p[1])
 
     def p_if_expr(self, p):
         # WARNING: Changing order of clauses produces Syntax Errors,
@@ -304,10 +331,12 @@ class Parser:
             p[0] = ast.IfExpression(p[2], p[4], p[6])
         else:
             p[0] = ast.IfExpression(p[2], p[4])
+        p[0].set_pos(p.lineno(1), p.lexpos(1))
 
     def p_match_expr(self, p):
-        """match_expr : MATCH expr WITH clause_seq END """
+        """match_expr : MATCH expr WITH clause_seq END"""
         p[0] = ast.MatchExpression(p[2], p[4])
+        p[0].set_pos(p.lineno(1), p.lexpos(1))
 
     def p_clause_seq(self, p):
         """clause_seq : clause PIPE clause_seq
@@ -317,12 +346,14 @@ class Parser:
     def p_clause(self, p):
         """clause : pattern ARROW expr"""
         p[0] = ast.Clause(p[1], p[3])
+        p[0].set_pos(p[1])
 
     def p_pattern(self, p):
         """pattern : CONID simple_pattern_list
                    | simple_pattern"""
         if len(p) == 3:
             p[0] = ast.Pattern(p[1], p[2])
+            p[0].set_pos(p.lineno(1), p.lexpos(1))
         else:
             p[0] = p[1]
 
@@ -349,10 +380,12 @@ class Parser:
         """bconst_simple_pattern : TRUE
                                  | FALSE"""
         p[0] = ast.ConstExpression(type.Bool(), p[1])
+        p[0].set_pos(p.lineno(1), p.lexpos(1))
 
     def p_cconst_simple_pattern(self, p):
         """cconst_simple_pattern : CCONST"""
         p[0] = ast.ConstExpression(type.Char(), p[1])
+        p[0].set_pos(p.lineno(1), p.lexpos(1))
 
     def p_fconst_simple_pattern(self, p):
         """fconst_simple_pattern : FPLUS FCONST
@@ -361,14 +394,17 @@ class Parser:
             p[0] = ast.ConstExpression(type.Float(), p[2])
         else:
             p[0] = ast.ConstExpression(type.Float(), p[1])
+        p[0].set_pos(p.lineno(1), p.lexpos(1))
 
     def p_mfconst_simple_pattern(self, p):
         """mfconst_simple_pattern : FMINUS FCONST"""
         p[0] = ast.ConstExpression(type.Float(), -p[2])
+        p[0].set_pos(p.lineno(1), p.lexpos(1))
 
     def p_genid_simple_pattern(self, p):
         """genid_simple_pattern : GENID"""
         p[0] = ast.GenidPattern(p[1])
+        p[0].set_pos(p.lineno(1), p.lexpos(1))
 
     def p_iconst_simple_pattern(self, p):
         """iconst_simple_pattern : PLUS ICONST
@@ -377,18 +413,22 @@ class Parser:
             p[0] = ast.ConstExpression(type.Int(), p[2])
         else:
             p[0] = ast.ConstExpression(type.Int(), p[1])
+        p[0].set_pos(p.lineno(1), p.lexpos(1))
 
     def p_miconst_simple_pattern(self, p):
         """miconst_simple_pattern : MINUS ICONST"""
         p[0] = ast.ConstExpression(type.Int(), -p[2])
+        p[0].set_pos(p.lineno(1), p.lexpos(1))
 
     def p_new_expr(self, p):
         """new_expr : NEW type"""
         p[0] = ast.NewExpression(p[2])
+        p[0].set_pos(p.lineno(1), p.lexpos(1))
 
     def p_while_expr(self, p):
         """while_expr : WHILE expr DO expr DONE"""
         p[0] = ast.WhileExpression(p[2], p[4])
+        p[0].set_pos(p.lineno(1), p.lexpos(1))
 
     def p_variable_def(self, p):
         """variable_def : array_variable_def
@@ -402,6 +442,7 @@ class Parser:
             p[0] = ast.ArrayVariableDef(p[2], p[4], p[7])
         else:
             p[0] = ast.ArrayVariableDef(p[2], p[4])
+        p[0].set_pos(p.lineno(1), p.lexpos(1))
 
     def p_expr_comma_seq(self, p):
         """expr_comma_seq : expr COMMA expr_comma_seq
@@ -415,10 +456,12 @@ class Parser:
             p[0] = ast.VariableDef(p[2], p[4])
         else:
             p[0] = ast.VariableDef(p[2])
+        p[0].set_pos(p.lineno(1), p.lexpos(1))
 
     def p_typedef(self, p):
         """typedef : TYPE tdef_and_seq"""
         p[0] = ast.TypeDefList(p[2])
+        p[0].set_pos(p.lineno(1), p.lexpos(1))
         self.typeTable.process(p[0])
 
     def p_tdef_and_seq(self, p):
@@ -429,6 +472,7 @@ class Parser:
     def p_tdef(self, p):
         """tdef : GENID EQ constr_pipe_seq"""
         p[0] = ast.TDef(p[1], p[3])
+        p[0].set_pos(p.lineno(1), p.lexpos(1))
 
     def p_constr_pipe_seq(self, p):
         """constr_pipe_seq : constr PIPE constr_pipe_seq
@@ -442,6 +486,7 @@ class Parser:
             p[0] = ast.Constructor(p[1], p[3])
         else:
             p[0] = ast.Constructor(p[1])
+        p[0].set_pos(p.lineno(1), p.lexpos(1))
 
     def p_type_seq(self, p):
         """type_seq : type type_seq

--- a/compiler/type.py
+++ b/compiler/type.py
@@ -154,10 +154,14 @@ class Table(Type):
         # First, insert all newly-defined types.
         for tdef in typeDefList:
             newtype = User(tdef.name)
+            newtype.set_pos(tdef)
             if newtype in self.knownTypes:
                 self._logger.error(
-                    # FIXME Add meaningful line
-                    "error: Type reuse: %s" % (newtype.name)
+                    "%d:%d: error: Redefining type '%s'" % (
+                        newtype.lineno,
+                        newtype.lexpos,
+                        newtype.name
+                    )
                     # TODO Show previous definition
                 )
             elif newtype.name in builtin_map:
@@ -174,18 +178,25 @@ class Table(Type):
             for constructor in tdef:
                 if constructor.name in self.knownConstructors:
                     self._logger.error(
-                        # FIXME add meaningful line
-                        "error: Constructor reuse: %s" % (constructor.name)
-                        # TODO Show previous use
+                        "%d:%d: error: Reusing constructor '%s'" % (
+                            constructor.lineno,
+                            constructor.lexpos,
+                            constructor.name
+                        )
+                        # TODO Show previous use and type
                     )
                 else:
                     for argType in constructor.list:
                         if argType not in self.knownTypes:
                             self._logger.error(
-                                # FIXME Add meaningful line
-                                "error: Type not defined: %s" % (argType.name)
+                                    "%d:%d: error: Undefined type '%s'" % (
+                                    argType.lexpos,
+                                    argType.lineno,
+                                    argType.name
+                                )
                             )
                     userType = User(tdef.name)
+                    userType.set_pos(tdef)
                     self.knownConstructors[constructor.name] = {
                         "type": userType,
                         "params": constructor.list

--- a/compiler/type.py
+++ b/compiler/type.py
@@ -30,6 +30,12 @@ class Type():
         """Simple hash. Override as needed."""
         return hash(self.name)
 
+    def copy_pos(self, node):
+        """Copy line info from another Type node."""
+        self.lineno = node.lineno
+        self.lexpos = node.lexpos
+
+
 class Builtin(Type):
     def __init__(self):
         self.name = self.__class__.__name__.lower()
@@ -156,7 +162,7 @@ class Table(Type):
         # First, insert all newly-defined types.
         for tdef in typeDefList:
             newtype = User(tdef.name)
-            newtype.set_pos(tdef)
+            newtype.copy_pos(tdef)
             if newtype in self.knownTypes:
                 self._logger.error(
                     "%d:%d: error: Redefining type '%s'" % (
@@ -201,7 +207,7 @@ class Table(Type):
                                 )
                             )
                     userType = User(tdef.name)
-                    userType.set_pos(tdef)
+                    userType.copy_pos(tdef)
                     self.knownConstructors[constructor.name] = {
                         "type": userType,
                         "params": constructor.list,

--- a/compiler/type.py
+++ b/compiler/type.py
@@ -136,6 +136,8 @@ class Table(Type):
     # Each key contains a dict:
     #   type:    type which the constructor belongs to
     #   params:  type arguments of the constructor
+    #   lineno:  line where constructor is defined
+    #   lexpos:  column where constructor is defined
     knownConstructors = {}
 
     # Logger used for logging events. Possibly shared with other modules.
@@ -177,13 +179,16 @@ class Table(Type):
         for tdef in typeDefList:
             for constructor in tdef:
                 if constructor.name in self.knownConstructors:
+                    alias = self.knownConstructors[constructor.name]
                     self._logger.error(
-                        "%d:%d: error: Reusing constructor '%s'" % (
+                        "%d:%d: error: Redefining constructor '%s'"
+                        "\tPrevious definition: %d:%d" % (
                             constructor.lineno,
                             constructor.lexpos,
-                            constructor.name
+                            constructor.name,
+                            alias['lineno'],
+                            alias['lexpos']
                         )
-                        # TODO Show previous use and type
                     )
                 else:
                     for argType in constructor.list:
@@ -199,7 +204,9 @@ class Table(Type):
                     userType.set_pos(tdef)
                     self.knownConstructors[constructor.name] = {
                         "type": userType,
-                        "params": constructor.list
+                        "params": constructor.list,
+                        "lineno": constructor.lineno,
+                        "lexpos": constructor.lexpos
                     }
 
         # TODO: Emmit warnings when typenames clash with definition names.

--- a/compiler/type.py
+++ b/compiler/type.py
@@ -14,6 +14,8 @@
 
 class Type():
     name = None
+    lineno = None
+    lexpos = None
 
     def __init__(self):
         raise NotImplementedError
@@ -27,7 +29,6 @@ class Type():
     def __hash__(self):
         """Simple hash. Override as needed."""
         return hash(self.name)
-
 
 class Builtin(Type):
     def __init__(self):


### PR DESCRIPTION
### Parser:
- AST and Type nodes are decorated with line info during parsing.
### Type:
- Errors now contain line full line info, including previous definitions, etc.
