### PR TITLE
Refactor AST hierarchy. Improve processing of user-defined types.

### DIFF
--- a/compiler/ast.py
+++ b/compiler/ast.py
@@ -64,6 +64,10 @@ class NameNode(Node):
 
 
 class ListNode(Node):
+    """
+    A node carrying a list of ast nodes.
+    Supports iterating through the nodes list.
+    """
     list = None
 
     def __iter__(self):
@@ -83,12 +87,12 @@ class Builtin(Type):
 # == AST REPRESENTATION OF PROGRAM ELEMENTS ==
 
 
-class Program(DataNode):
+class Program(ListNode):
     def __init__(self, list):
         self.list = list
 
 
-class LetDef(Node):
+class LetDef(ListNode):
     def __init__(self, list, isRec=False):
         self.list = list
         self.isRec = isRec
@@ -121,13 +125,13 @@ class UnaryExpression(Expression):
         self.operand = operand
 
 
-class ConstructorCallExpression(Expression):
+class ConstructorCallExpression(Expression, ListNode):
     def __init__(self, name, list):
         self.name = name
         self.list = list
 
 
-class ArrayExpression(Expression):
+class ArrayExpression(Expression, ListNode):
     def __init__(self, name, list):
         self.name = name
         self.list = list
@@ -169,7 +173,7 @@ class ForExpression(Expression):
         self.isDown = isDown
 
 
-class FunctionCallExpression(Expression):
+class FunctionCallExpression(Expression, ListNode):
     def __init__(self, name, list):
         self.name = name
         self.list = list
@@ -188,7 +192,7 @@ class IfExpression(Expression):
         self.elseExpr = elseExpr
 
 
-class MatchExpression(Expression):
+class MatchExpression(Expression, ListNode):
     def __init__(self, expr, list):
         self.expr = expr
         self.list = list
@@ -200,7 +204,7 @@ class Clause(Node):
         self.expr = expr
 
 
-class Pattern(Node):
+class Pattern(ListNode):
     def __init__(self, name, list):
         self.name = name
         self.list = list

--- a/compiler/ast.py
+++ b/compiler/ast.py
@@ -80,12 +80,12 @@ class ListNode(Node):
         return iter(self.list)
 
 
-class Type(NameNode):
-    """An AST node representing a type."""
+class Type(Node):
+    """A node representing a type."""
     pass
 
 
-class Builtin(Type):
+class Builtin(Type, NameNode):
     """One of the builtin types."""
     def __init__(self):
         self.name = self.__class__.__name__.lower()
@@ -293,7 +293,7 @@ builtin_map = {
 }
 
 
-class User(Type):
+class User(Type, NameNode):
     """A user-defined type."""
 
     def __init__(self, name):

--- a/compiler/ast.py
+++ b/compiler/ast.py
@@ -280,7 +280,7 @@ class Unit(Builtin):
     pass
 
 
-builtin_map = {
+builtin_types_map = {
     "bool": Bool,
     "char": Char,
     "float": Float,

--- a/compiler/ast.py
+++ b/compiler/ast.py
@@ -21,6 +21,16 @@ class Node:
     def __init__(self):
         raise NotImplementedError
 
+    def __eq__(self, other):
+        """
+        Two nodes are equal if they are of the same type
+        and have all attributes equal. Override as needed.
+        """
+        return type(self) == type(other) and all(
+            getattr(self, attr) == getattr(other, attr)
+            for attr in self.__dict__.keys()
+        )
+
     def copy_pos(self, node):
         """Copy line info from another AST node."""
         self.lineno = node.lineno
@@ -51,12 +61,8 @@ class NameNode(Node):
     name = None
 
     def __eq__(self, other):
-        """Simple and strict type equality. Override as needed."""
-        return all((
-            self.name is not None,
-            other.name is not None,
-            self.name == other.name
-        ))
+        """Equality testing based on name equality."""
+        return isinstance(other, NameNode) and self.name == other.name
 
     def __hash__(self):
         """Simple hash. Override as needed."""
@@ -293,37 +299,16 @@ class User(Type):
     def __init__(self, name):
         self.name = name
 
-    def __hash__(self):
-        return hash('user' + self.name)
-
 
 class Ref(Type):
     def __init__(self, type):
         self.type = type
-
-    def __eq__(self, other):
-        return isinstance(other, Ref) and self.type == other.type
-
-    def __hash__(self):
-        # Merkle-Damgard!
-        return hash('ref' + hash(self.type))
 
 
 class Array(Type):
     def __init__(self, type, dimensions=1):
         self.type = type
         self.dimensions = dimensions
-
-    def __eq__(self, other):
-        return all((
-            isinstance(other, Array),
-            self.dimensions == other.dimensions,
-            self.type == other.type
-        ))
-
-    def __hash__(self):
-        # Merkle-Damgard!
-        return hash('array' + str(self.dimensions) + hash(self.type))
 
 
 def String():
@@ -335,14 +320,3 @@ class Function(Type):
     def __init__(self, fromType, toType):
         self.fromType = fromType
         self.toType = toType
-
-    def __eq__(self, other):
-        return all((
-            isinstance(other, Function),
-            self.fromType == other.fromType,
-            self.toType == other.toType
-        ))
-
-    def __hash__(self):
-        # Merkle-Damgard!
-        return hash('function' + hash(self.fromType) + hash(self.toType))

--- a/compiler/ast.py
+++ b/compiler/ast.py
@@ -11,6 +11,7 @@
 # ----------------------------------------------------------------------
 """
 
+# == INTERFACES OF AST NODES ==
 
 class Node:
     lineno = None
@@ -24,18 +25,61 @@ class Node:
         self.lineno = node.lineno
         self.lexpos = node.lexpos
 
+
+class DataNode(Node):
+    """A node to which a definite type can and should be assigned."""
+    type = None
+
+
+class Expression(DataNode):
+    """An expression that can be evaluated."""
+    pass
+
+
+class Def(Node):
+    """Definition of a new name."""
+    pass
+
+
+class NameNode(Node):
+    """
+    A node with a user-defined name.
+    Supports equality testing based on name equality;
+    provides basic hashing functionality.
+    """
+    name = None
+
+    def __eq__(self, other):
+        """Simple and strict type equality. Override as needed."""
+        return all((
+            self.name is not None,
+            other.name is not None,
+            self.name == other.name
+        ))
+
+    def __hash__(self):
+        """Simple hash. Override as needed."""
+        return hash(self.name)
+
+
 class ListNode(Node):
     list = None
-
-    def __init__(self):
-        raise NotImplementedError
 
     def __iter__(self):
         return iter(self.list)
 
-class DataNode(Node):
+
+class Type(NameNode):
+    """An AST node representing a type."""
+    pass
+
+
+class Builtin(Type):
+    """One of the builtin types."""
     def __init__(self):
-        raise NotImplementedError
+        self.name = self.__class__.__name__.lower()
+
+# == AST REPRESENTATION OF PROGRAM ELEMENTS ==
 
 class Program(DataNode):
     def __init__(self, list):
@@ -45,10 +89,6 @@ class LetDef(Node):
     def __init__(self, list, isRec=False):
         self.list = list
         self.isRec = isRec
-
-class Def(Node):
-    def __init__(self):
-        raise NotImplementedError
 
 class FunctionDef(Def):
     def __init__(self, name, params, body, type=None):
@@ -61,10 +101,6 @@ class Param(DataNode):
     def __init__(self, name, type=None):
         self.name = name
         self.type = type
-
-class Expression(DataNode):
-    def __init__(self):
-        raise NotImplementedError
 
 class BinaryExpression(Expression):
     def __init__(self, leftOperand, operator, rightOperand):
@@ -181,47 +217,15 @@ class TDef(ListNode):
         self.type = type
         self.list = list
 
-class NameNode(Node):
-    """An AST node with a name and basic equality testing."""
-    name = None
-
-    def __init__(self):
-        raise NotImplementedError
-
-    def __eq__(self, other):
-        """Simple and strict type equality. Override as needed."""
-        if self.name is None or other.name is None:
-            return False
-        return self.name == other.name
-
-    def __hash__(self):
-        """Simple hash. Override as needed."""
-        return hash(self.name)
-
 
 class Constructor(NameNode, ListNode):
     def __init__(self, name, list=None):
         self.name = name
         self.list = list or []
 
-# == AST REPRESENTATION OF TYPES ==
+# == REPRESENTATION OF TYPES AS AST NODES ==
 
-class Type(NameNode):
-    """An AST node representing a type."""
-    pass
-
-
-class Builtin(Type):
-    """One of llama's builtin types."""
-    def __init__(self):
-        self.name = self.__class__.__name__.lower()
-
-
-class Unit(Builtin):
-    pass
-
-
-class Int(Builtin):
+class Bool(Builtin):
     pass
 
 
@@ -229,12 +233,17 @@ class Char(Builtin):
     pass
 
 
-class Bool(Builtin):
-    pass
-
-
 class Float(Builtin):
     pass
+
+
+class Int(Builtin):
+    pass
+
+
+class Unit(Builtin):
+    pass
+
 
 builtin_map = {
     "bool": Bool,

--- a/compiler/ast.py
+++ b/compiler/ast.py
@@ -29,6 +29,7 @@ class Node:
         return type(self) == type(other) and all(
             getattr(self, attr) == getattr(other, attr)
             for attr in self.__dict__.keys()
+            if attr not in ('lineno', 'lexpos')
         )
 
     def copy_pos(self, node):
@@ -55,14 +56,9 @@ class Def(Node):
 class NameNode(Node):
     """
     A node with a user-defined name.
-    Supports equality testing based on name equality;
-    provides basic hashing functionality.
+    Provides basic hashing functionality.
     """
     name = None
-
-    def __eq__(self, other):
-        """Equality testing based on name equality."""
-        return isinstance(other, NameNode) and self.name == other.name
 
     def __hash__(self):
         """Simple hash. Override as needed."""

--- a/compiler/ast.py
+++ b/compiler/ast.py
@@ -177,8 +177,8 @@ class TypeDefList(ListNode):
         self.list = list
 
 class TDef(ListNode):
-    def __init__(self, name, list):
-        self.name = name
+    def __init__(self, type, list):
+        self.type = type
         self.list = list
 
 class NameNode(Node):
@@ -200,8 +200,6 @@ class NameNode(Node):
 
 
 class Constructor(NameNode, ListNode):
-    type = None  # To be filled during type analysis
-
     def __init__(self, name, list=None):
         self.name = name
         self.list = list or []

--- a/compiler/ast.py
+++ b/compiler/ast.py
@@ -181,16 +181,12 @@ class TDef(ListNode):
         self.name = name
         self.list = list
 
-class Constructor(ListNode):
-    def __init__(self, name, list=None):
-        self.name = name
-        self.list = list or []
-
-# == AST REPRESENTATION OF TYPES ==
-
-class Type(Node):
-    """An AST node representing a type."""
+class NameNode(Node):
+    """An AST node with a name and basic equality testing."""
     name = None
+
+    def __init__(self):
+        raise NotImplementedError
 
     def __eq__(self, other):
         """Simple and strict type equality. Override as needed."""
@@ -202,10 +198,19 @@ class Type(Node):
         """Simple hash. Override as needed."""
         return hash(self.name)
 
-    def copy_pos(self, node):
-        """Copy line info from another Type node."""
-        self.lineno = node.lineno
-        self.lexpos = node.lexpos
+
+class Constructor(NameNode, ListNode):
+    type = None  # To be filled during type analysis
+
+    def __init__(self, name, list=None):
+        self.name = name
+        self.list = list or []
+
+# == AST REPRESENTATION OF TYPES ==
+
+class Type(NameNode):
+    """An AST node representing a type."""
+    pass
 
 
 class Builtin(Type):

--- a/compiler/ast.py
+++ b/compiler/ast.py
@@ -13,6 +13,7 @@
 
 # == INTERFACES OF AST NODES ==
 
+
 class Node:
     lineno = None
     lexpos = None
@@ -81,14 +82,17 @@ class Builtin(Type):
 
 # == AST REPRESENTATION OF PROGRAM ELEMENTS ==
 
+
 class Program(DataNode):
     def __init__(self, list):
         self.list = list
+
 
 class LetDef(Node):
     def __init__(self, list, isRec=False):
         self.list = list
         self.isRec = isRec
+
 
 class FunctionDef(Def):
     def __init__(self, name, params, body, type=None):
@@ -97,10 +101,12 @@ class FunctionDef(Def):
         self.body = body
         self.type = type
 
+
 class Param(DataNode):
     def __init__(self, name, type=None):
         self.name = name
         self.type = type
+
 
 class BinaryExpression(Expression):
     def __init__(self, leftOperand, operator, rightOperand):
@@ -108,42 +114,51 @@ class BinaryExpression(Expression):
         self.operator = operator
         self.rightOperand = rightOperand
 
+
 class UnaryExpression(Expression):
     def __init__(self, operator, operand):
         self.operator = operator
         self.operand = operand
+
 
 class ConstructorCallExpression(Expression):
     def __init__(self, name, list):
         self.name = name
         self.list = list
 
+
 class ArrayExpression(Expression):
     def __init__(self, name, list):
         self.name = name
         self.list = list
+
 
 class ConstExpression(Expression):
     def __init__(self, type, value=None):
         self.type = type
         self.value = value
 
+
 class ConidExpression(Expression):
     def __init__(self, name):
         self.name = name
+
 
 class GenidExpression(Expression):
     def __init__(self, name):
         self.name = name
 
+
 class DeleteExpression(Expression):
     def __init__(self, expr):
         self.expr = expr
+
 
 class DimExpression(Expression):
     def __init__(self, name, dimension=1):
         self.name = name
         self.dimension = dimension
+
 
 class ForExpression(Expression):
     def __init__(self, counter, startExpr, stopExpr, body, isDown=False):
@@ -153,15 +168,18 @@ class ForExpression(Expression):
         self.body = body
         self.isDown = isDown
 
+
 class FunctionCallExpression(Expression):
     def __init__(self, name, list):
         self.name = name
         self.list = list
 
+
 class LetInExpression(Expression):
     def __init__(self, letdef, expr):
         self.letdef = letdef
         self.expr = expr
+
 
 class IfExpression(Expression):
     def __init__(self, condition, thenExpr, elseExpr=None):
@@ -169,38 +187,46 @@ class IfExpression(Expression):
         self.thenExpr = thenExpr
         self.elseExpr = elseExpr
 
+
 class MatchExpression(Expression):
     def __init__(self, expr, list):
         self.expr = expr
         self.list = list
+
 
 class Clause(Node):
     def __init__(self, pattern, expr):
         self.pattern = pattern
         self.expr = expr
 
+
 class Pattern(Node):
     def __init__(self, name, list):
         self.name = name
         self.list = list
 
+
 class GenidPattern(Node):
     def __init__(self, name):
         self.name = name
 
+
 class NewExpression(Expression):
     def __init__(self, type):
         self.type = type
+
 
 class WhileExpression(Expression):
     def __init__(self, condition, body):
         self.condition = condition
         self.body = body
 
+
 class VariableDef(Def):
     def __init__(self, name, type=None):
         self.name = name
         self.type = type
+
 
 class ArrayVariableDef(VariableDef):
     def __init__(self, name, dimensions, itemType=None):
@@ -208,9 +234,11 @@ class ArrayVariableDef(VariableDef):
         self.dimensions = dimensions
         self.type = Array(itemType, dimensions)
 
+
 class TypeDefList(ListNode):
     def __init__(self, list):
         self.list = list
+
 
 class TDef(ListNode):
     def __init__(self, type, list):
@@ -224,6 +252,7 @@ class Constructor(NameNode, ListNode):
         self.list = list or []
 
 # == REPRESENTATION OF TYPES AS AST NODES ==
+
 
 class Bool(Builtin):
     pass
@@ -252,6 +281,7 @@ builtin_map = {
     "int": Int,
     "unit": Unit,
 }
+
 
 class User(Type):
     """A user-defined type."""

--- a/compiler/ast.py
+++ b/compiler/ast.py
@@ -229,10 +229,10 @@ class VariableDef(Def):
 
 
 class ArrayVariableDef(VariableDef):
-    def __init__(self, name, dimensions, itemType=None):
+    def __init__(self, name, dimensions, type=None):
         self.name = name
         self.dimensions = dimensions
-        self.type = Array(itemType, dimensions)
+        self.type = type
 
 
 class TypeDefList(ListNode):

--- a/compiler/error.py
+++ b/compiler/error.py
@@ -10,11 +10,13 @@
 
 import logging
 
+
 def _format(f):
     def new_f(self, fmt, *args):
         msg = fmt % args  # Let it throw, let it throw, let it throw
         f(self, msg)
     return new_f
+
 
 class LoggerInterface:
     """

--- a/compiler/lex.py
+++ b/compiler/lex.py
@@ -188,7 +188,12 @@ class _LexerBuilder:
         self.logger = logger
         self.verbose = verbose
         if self.verbose:
-            self.logger.info(__name__ + ': _LexerBuilder: wrapper initialized')
+            self.logger.info(
+                "%s: %s: %s",
+                __name__,
+                self.__class__.__name__,
+                'wrapper initialized'
+            )
 
     # == REQUIRED METHODS ==
 
@@ -201,7 +206,12 @@ class _LexerBuilder:
         """
         self.lexer = lex.lex(module=self, **kwargs)
         if self.verbose:
-            self.logger.info(__name__ + ': _LexerBuilder: lexer ready ')
+            self.logger.info(
+                "%s: %s: %s",
+                __name__,
+                self.__class__.__name__,
+                'lexer ready'
+            )
 
     # A wrapper around the function of the inner lexer
     def token(self):
@@ -471,7 +481,7 @@ class Lexer:
     _lexer = None
 
     # Logger used for logging events. Possibly shared with other modules.
-    _logger = None
+    logger = None
 
     # == REQUIRED METHODS (see _LexerBuilder for details) ==
 
@@ -481,7 +491,7 @@ class Lexer:
 
     def __init__(self, logger, verbose=False, **kwargs):
         """Create a new lexer."""
-        self._logger = logger
+        self.logger = logger
         self._lexer = _LexerBuilder(logger=logger, verbose=verbose)
         self._lexer.build(**kwargs)
 
@@ -490,7 +500,12 @@ class Lexer:
         self.input = self._lexer.input
         self.skip  = self._lexer.skip
         if verbose:
-            self._logger.info(__name__ + ': Lexer: lexer ready')
+            self.logger.info(
+                "%s: %s: %s",
+                __name__,
+                self.__class__.__name__,
+                'lexer ready'
+            )
 
     # == EXPORT POSITION ATTRIBUTES ==
 

--- a/compiler/lex.py
+++ b/compiler/lex.py
@@ -71,6 +71,7 @@ def unescape(string):
     """Return unescaped string."""
     return bytes(string, 'ascii').decode('unicode_escape')
 
+
 def explode(string):
     """Unescape, null-terminate and listify string."""
     string = list(unescape(string))

--- a/compiler/parse.py
+++ b/compiler/parse.py
@@ -125,7 +125,7 @@ class Parser:
                         | FLOAT
                         | INT
                         | UNIT"""
-        p[0] = ast.builtin_map[p[1]]()
+        p[0] = ast.builtin_types_map[p[1]]()
         _track(p)
 
     def p_derived_type(self, p):

--- a/compiler/parse.py
+++ b/compiler/parse.py
@@ -5,8 +5,7 @@
 # parser for the Llama language
 # http://courses.softlab.ntua.gr/compilers/2012a/llama2012.pdf
 #
-# Authors: Dimitris Koutsoukos <dim.kou.shmmy@gmail.com>
-#          Nick Korasidis <Renelvon@gmail.com>
+# Authors: Dimitris Koutsoukos <dim.kou.shmmy@gmail.com> #          Nick Korasidis <Renelvon@gmail.com>
 #          Dionysis Zindros <dionyziz@gmail.com>
 # ----------------------------------------------------------------------
 """
@@ -537,16 +536,16 @@ class Parser:
     typeTable = None
     verbose = False
 
-    def __init__(self, logger, **kwargs):
+    def __init__(self, logger, verbose=False, **kwargs):
         """Create a parser for the entire Llama grammar."""
         self.logger = logger
-        self.typeTable = type.Table(logger=self.logger)
+        self.verbose = verbose
         self.parser = yacc.yacc(module=self, **kwargs)
+        self.typeTable = type.Table(logger=self.logger)
 
-    def parse(self, data, lexer, verbose=False):
+    def parse(self, data, lexer):
         """
         Parse the input and return the AST. If 'debug' is set,
         output matched productions, state and other info to stdout.
         """
-        self.verbose = verbose
         return self.parser.parse(data, lexer, debug=self.verbose)

--- a/compiler/parse.py
+++ b/compiler/parse.py
@@ -451,7 +451,9 @@ class Parser:
         """array_variable_def : MUTABLE GENID LBRACKET expr_comma_seq RBRACKET COLON type
                               | MUTABLE GENID LBRACKET expr_comma_seq RBRACKET"""
         if len(p) == 8:
-            p[0] = ast.ArrayVariableDef(p[2], p[4], p[7])
+            arrtype = ast.Array(p[7], len(p[4]))
+            arrtype.copy_pos(p[7])
+            p[0] = ast.ArrayVariableDef(p[2], p[4], arrtype)
         else:
             p[0] = ast.ArrayVariableDef(p[2], p[4])
         _track(p)
@@ -465,7 +467,9 @@ class Parser:
         """simple_variable_def : MUTABLE GENID
                                | MUTABLE GENID COLON type"""
         if len(p) == 5:
-            p[0] = ast.VariableDef(p[2], p[4])
+            vartype = ast.Ref(p[4])
+            vartype.copy_pos(p[4])
+            p[0] = ast.VariableDef(p[2], vartype)
         else:
             p[0] = ast.VariableDef(p[2])
         _track(p)

--- a/compiler/parse.py
+++ b/compiler/parse.py
@@ -25,6 +25,7 @@ def _track(p):
         node.lineno = p.lineno(1)
         node.lexpos = p.lexpos(1)
 
+
 class Parser:
     """A parser for the Llama language"""
     precedence = (

--- a/compiler/parse.py
+++ b/compiler/parse.py
@@ -17,7 +17,7 @@ from compiler import ast, lex, type
 
 
 def _track(p):
-    if isinstance(p[1], (ast.Node, type.Type)):
+    if isinstance(p[1], ast.Node):
         if p[0] is not p[1]:
             p[0].copy_pos(p[1])
     else:
@@ -124,7 +124,7 @@ class Parser:
                         | FLOAT
                         | INT
                         | UNIT"""
-        p[0] = type.builtin_map[p[1]]()
+        p[0] = ast.builtin_map[p[1]]()
         _track(p)
 
     def p_derived_type(self, p):
@@ -139,9 +139,9 @@ class Parser:
         """array_type : ARRAY LBRACKET star_comma_seq RBRACKET OF type
                       | ARRAY OF type"""
         if len(p) == 7:
-            p[0] = type.Array(p[6], p[3])
+            p[0] = ast.Array(p[6], p[3])
         else:
-            p[0] = type.Array(p[3])
+            p[0] = ast.Array(p[3])
         _track(p)
 
     def p_star_comma_seq(self, p):
@@ -155,17 +155,17 @@ class Parser:
 
     def p_function_type(self, p):
         """function_type : type ARROW type"""
-        p[0] = type.Function(p[1], p[3])
+        p[0] = ast.Function(p[1], p[3])
         _track(p)
 
     def p_ref_type(self, p):
         """ref_type : type REF"""
-        p[0] = type.Ref(p[1])
+        p[0] = ast.Ref(p[1])
         _track(p)
 
     def p_user_type(self, p):
         """user_type : GENID"""
-        p[0] = type.User(p[1])
+        p[0] = ast.User(p[1])
         _track(p)
 
     def p_empty(self, p):
@@ -261,12 +261,12 @@ class Parser:
     def p_bconst_simple_expr(self, p):
         """bconst_simple_expr : TRUE
                               | FALSE"""
-        p[0] = ast.ConstExpression(type.Bool(), p[1])
+        p[0] = ast.ConstExpression(ast.Bool(), p[1])
         _track(p)
 
     def p_cconst_simple_expr(self, p):
         """cconst_simple_expr : CCONST"""
-        p[0] = ast.ConstExpression(type.Char(), p[1])
+        p[0] = ast.ConstExpression(ast.Char(), p[1])
         _track(p)
 
     def p_conid_simple_expr(self, p):
@@ -276,12 +276,12 @@ class Parser:
 
     def p_iconst_simple_expr(self, p):
         """iconst_simple_expr : ICONST"""
-        p[0] = ast.ConstExpression(type.Int(), p[1])
+        p[0] = ast.ConstExpression(ast.Int(), p[1])
         _track(p)
 
     def p_fconst_simple_expr(self, p):
         """fconst_simple_expr : FCONST"""
-        p[0] = ast.ConstExpression(type.Float(), p[1])
+        p[0] = ast.ConstExpression(ast.Float(), p[1])
         _track(p)
 
     def p_genid_simple_expr(self, p):
@@ -291,12 +291,12 @@ class Parser:
 
     def p_sconst_simple_expr(self, p):
         """sconst_simple_expr : SCONST"""
-        p[0] = ast.ConstExpression(type.String(), p[1])
+        p[0] = ast.ConstExpression(ast.String(), p[1])
         _track(p)
 
     def p_uconst_simple_expr(self, p):
         """uconst_simple_expr : LPAREN RPAREN"""
-        p[0] = ast.ConstExpression(type.Unit())
+        p[0] = ast.ConstExpression(ast.Unit())
         _track(p)
 
     def p_delete_expr(self, p):
@@ -390,26 +390,26 @@ class Parser:
     def p_bconst_simple_pattern(self, p):
         """bconst_simple_pattern : TRUE
                                  | FALSE"""
-        p[0] = ast.ConstExpression(type.Bool(), p[1])
+        p[0] = ast.ConstExpression(ast.Bool(), p[1])
         _track(p)
 
     def p_cconst_simple_pattern(self, p):
         """cconst_simple_pattern : CCONST"""
-        p[0] = ast.ConstExpression(type.Char(), p[1])
+        p[0] = ast.ConstExpression(ast.Char(), p[1])
         _track(p)
 
     def p_fconst_simple_pattern(self, p):
         """fconst_simple_pattern : FPLUS FCONST
                                  | FCONST"""
         if len(p) == 3:
-            p[0] = ast.ConstExpression(type.Float(), p[2])
+            p[0] = ast.ConstExpression(ast.Float(), p[2])
         else:
-            p[0] = ast.ConstExpression(type.Float(), p[1])
+            p[0] = ast.ConstExpression(ast.Float(), p[1])
         _track(p)
 
     def p_mfconst_simple_pattern(self, p):
         """mfconst_simple_pattern : FMINUS FCONST"""
-        p[0] = ast.ConstExpression(type.Float(), -p[2])
+        p[0] = ast.ConstExpression(ast.Float(), -p[2])
         _track(p)
 
     def p_genid_simple_pattern(self, p):
@@ -421,14 +421,14 @@ class Parser:
         """iconst_simple_pattern : PLUS ICONST
                                  | ICONST"""
         if len(p) == 3:
-            p[0] = ast.ConstExpression(type.Int(), p[2])
+            p[0] = ast.ConstExpression(ast.Int(), p[2])
         else:
-            p[0] = ast.ConstExpression(type.Int(), p[1])
+            p[0] = ast.ConstExpression(ast.Int(), p[1])
         _track(p)
 
     def p_miconst_simple_pattern(self, p):
         """miconst_simple_pattern : MINUS ICONST"""
-        p[0] = ast.ConstExpression(type.Int(), -p[2])
+        p[0] = ast.ConstExpression(ast.Int(), -p[2])
         _track(p)
 
     def p_new_expr(self, p):

--- a/compiler/parse.py
+++ b/compiler/parse.py
@@ -5,7 +5,8 @@
 # parser for the Llama language
 # http://courses.softlab.ntua.gr/compilers/2012a/llama2012.pdf
 #
-# Authors: Dimitris Koutsoukos <dim.kou.shmmy@gmail.com> #          Nick Korasidis <Renelvon@gmail.com>
+# Authors: Dimitris Koutsoukos <dim.kou.shmmy@gmail.com>
+#          Nick Korasidis <renelvon@gmail.com>
 #          Dionysis Zindros <dionyziz@gmail.com>
 # ----------------------------------------------------------------------
 """
@@ -514,7 +515,7 @@ class Parser:
     def p_error(self, p):
         """Signal syntax error"""
         self.logger.error(
-            "%d:%d: error: Syntax error on token %s\t%s",
+            "%d:%d: error: Syntax error on token %s (value: %s)",
             p.lineno,
             p.lexpos,
             p.type,
@@ -547,6 +548,13 @@ class Parser:
         self.logger = logger
         self.verbose = verbose
         self.parser = yacc.yacc(module=self, **kwargs)
+        if verbose:
+            self.logger.info(
+                "%s: %s: %s",
+                __name__,
+                self.__class__.__name__,
+                'parser ready'
+            )
         self.typeTable = type.Table(logger=self.logger)
 
     def parse(self, data, lexer):

--- a/compiler/parse.py
+++ b/compiler/parse.py
@@ -489,7 +489,7 @@ class Parser:
     def p_tdef(self, p):
         """tdef : user_type EQ constr_pipe_seq
                 | builtin_type EQ constr_pipe_seq"""
-        # Flagging redefinition of builtin_types delegated to typesem module.
+        # Flagging redefinition of builtin_types delegated to type module.
         p[0] = ast.TDef(p[1], p[3])
         _track(p)
 

--- a/compiler/parse.py
+++ b/compiler/parse.py
@@ -482,7 +482,7 @@ class Parser:
         self._expand_seq(p)
 
     def p_tdef(self, p):
-        """tdef : GENID EQ constr_pipe_seq"""
+        """tdef : user_type EQ constr_pipe_seq"""
         p[0] = ast.TDef(p[1], p[3])
         _track(p)
 

--- a/compiler/parse.py
+++ b/compiler/parse.py
@@ -482,7 +482,9 @@ class Parser:
         self._expand_seq(p)
 
     def p_tdef(self, p):
-        """tdef : user_type EQ constr_pipe_seq"""
+        """tdef : user_type EQ constr_pipe_seq
+                | builtin_type EQ constr_pipe_seq"""
+        # Flagging redefinition of builtin_types delegated to typesem module.
         p[0] = ast.TDef(p[1], p[3])
         _track(p)
 

--- a/compiler/type.py
+++ b/compiler/type.py
@@ -46,8 +46,7 @@ class Table:
 
         # First, insert all newly-defined types.
         for tdef in typeDefList:
-            newtype = ast.User(tdef.name)
-            newtype.copy_pos(tdef)
+            newtype = tdef.type
             if newtype in self.knownTypes:
                 self._logger.error(
                     "%d:%d: error: Redefining type '%s'" % (
@@ -69,6 +68,7 @@ class Table:
         # Process each constructor.
         for tdef in typeDefList:
             for constructor in tdef:
+                constructor.type = tdef.type
                 if constructor.name in self.knownConstructors:
                     alias = self.knownConstructors[constructor.name]
                     self._logger.error(
@@ -91,8 +91,7 @@ class Table:
                                     argType.name
                                 )
                             )
-                    userType = ast.User(tdef.name)
-                    userType.copy_pos(tdef)
+                    userType = tdef.type
                     self.knownConstructors[constructor.name] = {
                         "type": userType,
                         "params": constructor.list,

--- a/compiler/type.py
+++ b/compiler/type.py
@@ -2,7 +2,7 @@
 # ----------------------------------------------------------------------
 # type.py
 #
-# Type management for Llama language
+# Semantic analysis of types
 # http://courses.softlab.ntua.gr/compilers/2012a/llama2012.pdf
 #
 # Authors: Dionysis Zindros <dionyziz@gmail.com>
@@ -11,132 +11,17 @@
 # ----------------------------------------------------------------------
 """
 
-
-class Type():
-    name = None
-    lineno = None
-    lexpos = None
-
-    def __init__(self):
-        raise NotImplementedError
-
-    def __eq__(self, other):
-        """Simple and strict type equality. Override as needed."""
-        if self.name is None or other.name is None:
-            return False
-        return self.name == other.name
-
-    def __hash__(self):
-        """Simple hash. Override as needed."""
-        return hash(self.name)
-
-    def copy_pos(self, node):
-        """Copy line info from another Type node."""
-        self.lineno = node.lineno
-        self.lexpos = node.lexpos
+from compiler import ast
 
 
-class Builtin(Type):
-    def __init__(self):
-        self.name = self.__class__.__name__.lower()
-
-
-class Unit(Builtin):
-    pass
-
-
-class Int(Builtin):
-    pass
-
-
-class Char(Builtin):
-    pass
-
-
-class Bool(Builtin):
-    pass
-
-
-class Float(Builtin):
-    pass
-
-builtin_map = {
-    "bool": Bool,
-    "char": Char,
-    "float": Float,
-    "int": Int,
-    "unit": Unit,
-}
-
-class User(Type):
-    name = None
-
-    def __init__(self, name):
-        self.name = name
-
-    def __hash__(self):
-        return hash('user' + self.name)
-
-
-class Ref(Type):
-    def __init__(self, type):
-        self.type = type
-
-    def __eq__(self, other):
-        return isinstance(other, Ref) and self.type == other.type
-
-    def __hash__(self):
-        # Merkle-Damgard!
-        return hash('ref' + hash(self.type))
-
-
-class Array(Type):
-    def __init__(self, type, dimensions=1):
-        self.type = type
-        self.dimensions = dimensions
-
-    def __eq__(self, other):
-        return all((
-            isinstance(other, Array),
-            self.dimensions == other.dimensions,
-            self.type == other.type
-        ))
-
-    def __hash__(self):
-        # Merkle-Damgard!
-        return hash('array' + str(self.dimensions) + hash(self.type))
-
-
-def String():
-    """Factory method to alias (internally) String type to Array of char."""
-    return Array(Char(), 1)
-
-
-class Function(Type):
-    def __init__(self, fromType, toType):
-        self.fromType = fromType
-        self.toType = toType
-
-    def __eq__(self, other):
-        return all((
-            isinstance(other, Function),
-            self.fromType == other.fromType,
-            self.toType == other.toType
-        ))
-
-    def __hash__(self):
-        # Merkle-Damgard!
-        return hash('function' + hash(self.fromType) + hash(self.toType))
-
-
-class Table(Type):
+class Table:
     """
     Database of all the program's types. Enables semantic checking
     of user defined types and more.
     """
 
-    # Sets of types encountered so far. Built-in types always available.
-    knownTypes = set(t() for t in builtin_map.values())
+    # Set of types encountered so far. Built-in types always available.
+    knownTypes = set(t() for t in ast.builtin_map.values())
 
     # Dictionary of constructors encountered so far.
     # Each key contains a dict:
@@ -161,7 +46,7 @@ class Table(Type):
 
         # First, insert all newly-defined types.
         for tdef in typeDefList:
-            newtype = User(tdef.name)
+            newtype = ast.User(tdef.name)
             newtype.copy_pos(tdef)
             if newtype in self.knownTypes:
                 self._logger.error(
@@ -172,7 +57,7 @@ class Table(Type):
                     )
                     # TODO Show previous definition
                 )
-            elif newtype.name in builtin_map:
+            elif newtype.name in ast.builtin_map:
                 self._logger.error(
                     # FIXME Add meaningful line
                     "error: Cannot redefine builtin type: %s" % (newtype.name)
@@ -206,7 +91,7 @@ class Table(Type):
                                     argType.name
                                 )
                             )
-                    userType = User(tdef.name)
+                    userType = ast.User(tdef.name)
                     userType.copy_pos(tdef)
                     self.knownConstructors[constructor.name] = {
                         "type": userType,
@@ -215,4 +100,4 @@ class Table(Type):
                         "lexpos": constructor.lexpos
                     }
 
-        # TODO: Emmit warnings when typenames clash with definition names.
+        # TODO: Emit warnings when typenames clash with definition names.

--- a/compiler/type.py
+++ b/compiler/type.py
@@ -32,11 +32,11 @@ class Table:
     knownConstructors = {}
 
     # Logger used for logging events. Possibly shared with other modules.
-    _logger = None
+    logger = None
 
     def __init__(self, logger):
         """Return a new TypeTable."""
-        self._logger = logger
+        self.logger = logger
 
     def process(self, typeDefList):
         """
@@ -48,7 +48,7 @@ class Table:
         for tdef in typeDefList:
             newtype = tdef.type
             if newtype in self.knownTypes:
-                self._logger.error(
+                self.logger.error(
                     "%d:%d: error: Redefining type '%s'" % (
                         newtype.lineno,
                         newtype.lexpos,
@@ -57,7 +57,7 @@ class Table:
                     # TODO Show previous definition
                 )
             elif newtype.name in ast.builtin_map:
-                self._logger.error(
+                self.logger.error(
                     # FIXME Add meaningful line
                     "error: Cannot redefine builtin type: %s" % (newtype.name)
                     # TODO Show previous definition
@@ -71,7 +71,7 @@ class Table:
                 constructor.type = tdef.type
                 if constructor.name in self.knownConstructors:
                     alias = self.knownConstructors[constructor.name]
-                    self._logger.error(
+                    self.logger.error(
                         "%d:%d: error: Redefining constructor '%s'"
                         "\tPrevious definition: %d:%d" % (
                             constructor.lineno,
@@ -84,7 +84,7 @@ class Table:
                 else:
                     for argType in constructor.list:
                         if argType not in self.knownTypes:
-                            self._logger.error(
+                            self.logger.error(
                                     "%d:%d: error: Undefined type '%s'" % (
                                     argType.lexpos,
                                     argType.lineno,

--- a/compiler/type.py
+++ b/compiler/type.py
@@ -21,7 +21,7 @@ class Table:
     """
 
     # Set of types encountered so far. Built-in types always available.
-    knownTypes = set(t() for t in ast.builtin_map.values())
+    knownTypes = set(t() for t in ast.builtin_types_map.values())
 
     # Dictionary of constructors encountered so far.
     # Each key contains a dict:
@@ -56,7 +56,7 @@ class Table:
                     )
                     # TODO Show previous definition
                 )
-            elif newtype.name in ast.builtin_map:
+            elif newtype.name in ast.builtin_types_map:
                 self.logger.error(
                     # FIXME Add meaningful line
                     "error: Cannot redefine builtin type: %s" % (newtype.name)

--- a/main.py
+++ b/main.py
@@ -138,7 +138,7 @@ def main():
         verbose=OPTS['lexer_verbose'])
 
     # Make a parser. By default, the parser is optimized
-    # (i.e. caches LALR tables accross invocations). A 'paser.out' file
+    # (i.e. caches LALR tables accross invocations). A 'parser.out' file
     # is created every time the tables are regenerated unless 'debug'
     # is set to 0.
     parser = parse.Parser(

--- a/main.py
+++ b/main.py
@@ -138,8 +138,9 @@ def main():
         verbose=OPTS['lexer_verbose'])
 
     # Make a parser. By default, the parser is optimized
-    # (i.e. caches LALR tables accross invocations). If 'debug' is set,
-    # a 'parser.out' is created every time the tables are regenerated.
+    # (i.e. caches LALR tables accross invocations). A 'paser.out' file
+    # is created every time the tables are regenerated unless 'debug'
+    # is set to 0.
     parser = parse.Parser(
         logger=logger,
         optimize=1,

--- a/main.py
+++ b/main.py
@@ -144,7 +144,8 @@ def main():
     parser = parse.Parser(
         logger=logger,
         optimize=1,
-        start='program'
+        start='program',
+        verbose=OPTS['parser_verbose']
     )
 
     # Stop here if this a dry run.
@@ -158,8 +159,7 @@ def main():
     # Parse and construct the AST.
     ast = parser.parse(
         data=data,
-        lexer=lexer,
-        verbose=OPTS['parser_verbose']
+        lexer=lexer
     )
 
     # On bad program, terminate with error.

--- a/tests/correct/bubblesort.lla
+++ b/tests/correct/bubblesort.lla
@@ -1,4 +1,4 @@
-let bsort x = 
+let bsort x =
    let swap x y =
       let t = !x in x := !y; y := t in
    let mutable changed in
@@ -7,15 +7,15 @@ let bsort x =
       changed := false;
       for i = 0 to dim x - 2 do
          if !x[i] > !x[i+1] then
-         begin	
+         begin
             swap x[i] x[i+1];
             changed := true
          end
       done
    done
 
-let main = 
-   let print_array msg x = 
+let main =
+   let print_array msg x =
       print_string msg;
       for i = 0 to dim x - 1 do
          if i > 0 then print_string ", ";

--- a/tests/correct/fibonacci.lla
+++ b/tests/correct/fibonacci.lla
@@ -3,14 +3,14 @@
  *)
 
 let rec fibo k n =
-   if k<=0 then 
+   if k<=0 then
       n:=0
-   else if k=1 then 
+   else if k=1 then
       n:=1
    else
       begin
          let mutable n1
-         and mutable n2 in 
+         and mutable n2 in
          fibo (k-1) n1;
          fibo (k-2) n2;
          n := !n1 + !n2

--- a/tests/correct/gcd.lla
+++ b/tests/correct/gcd.lla
@@ -4,9 +4,9 @@
 
 let gcd a b k =
    while !a > 0 && !b > 0 do
-      if !a > !b then 
+      if !a > !b then
          a := !a mod !b
-      else 
+      else
          b := !b mod !a
    done;
    k := !a+!b

--- a/tests/correct/hanoi1.lla
+++ b/tests/correct/hanoi1.lla
@@ -15,4 +15,3 @@ let main =
     print_string "Please, give the number of rings: ";
     let n = read_int () in
     hanoi n "left" "right" "middle"
-

--- a/tests/correct/hanoi2.lla
+++ b/tests/correct/hanoi2.lla
@@ -1,20 +1,20 @@
 type pile = Left | Middle | Right
 
-let print_pile pile = 
+let print_pile pile =
    match pile with
      Left   -> print_string "left"
    | Middle -> print_string "middle"
    | Right  -> print_string "right"
   end
 
-let main = 
+let main =
    let move source target =
       print_string "Moving from: ";
       print_pile source;
       print_string " to ";
       print_pile target;
       print_string "\n" in
-   let rec hanoi rings source target auxil = 
+   let rec hanoi rings source target auxil =
       if rings > 0 then
       begin
          hanoi (rings-1) source auxil target;
@@ -24,4 +24,3 @@ let main =
    print_string "Please, give the number of rings: ";
    let n = read_int () in
    hanoi n Left Right Middle
-

--- a/tests/correct/listInsert.lla
+++ b/tests/correct/listInsert.lla
@@ -7,21 +7,21 @@ type list = Nil | Cons of int list
 let rec listInsert (l : list) (d : int) : list =
    match l with
      Nil       -> Cons d Nil
-   | Cons m l1 -> if d <= m then 
+   | Cons m l1 -> if d <= m then
                      Cons d l
-                  else 
-                     Cons m (listInsert l1 d)  
-   end     
+                  else
+                     Cons m (listInsert l1 d)
+   end 
 
 let rec listPrint l =
    match l with
      Nil       -> print_string "NIL"
    | Cons n l1 -> print_int n;
                   print_string " -> ";
-                  listPrint l1  
-   end 
+                  listPrint l1
+   end
 
-let main = 
+let main =
    let mutable l in
    l := Nil;
    for i = 1 to 5 do

--- a/tests/correct/matrixMult.lla
+++ b/tests/correct/matrixMult.lla
@@ -32,7 +32,7 @@ let mprint m =
       print_string "\n"
    done
 
-let main = 
+let main =
    let mutable x[3,4]
    and mutable y[4,5]
    and mutable z[3,5] in

--- a/tests/correct/maze.lla
+++ b/tests/correct/maze.lla
@@ -6,14 +6,14 @@
 (* Minotaurus position in maze is marked with an 'M', Theseas intial position with a 'T' and the path that Theseas follows*)
 (* ommiting the dead ends that he may meet are markes with a '*' *)
 
-type obj = Wall | Empty | Path | Thread | Minotaurus | Theseas_InitialPos 
+type obj = Wall | Empty | Path | Thread | Minotaurus | Theseas_InitialPos
 
 let print_maze maze =
    print_string "\n\n\t    " ;
    for j = 0 to dim 2 maze - 1 do print_int (j / 10) done ;
       print_string "\n\t    " ;
-      for j = 0 to dim 2 maze - 1 do 
-         print_int (j mod 10) 
+      for j = 0 to dim 2 maze - 1 do
+         print_int (j mod 10)
       done ;
       print_string "\n\n\t " ;
       for i = 0 to dim 1 maze - 1 do
@@ -28,9 +28,9 @@ let print_maze maze =
             | Path               -> print_char '*'
             | Minotaurus         -> print_char 'M'
             | Theseas_InitialPos -> print_char 'T' 
-            end 
-         done ; 
-      print_string "\n\t " 
+            end
+         done ;
+      print_string "\n\t "
    done ;
    print_string "\n\n"
 	
@@ -39,58 +39,58 @@ let fill_maze maze seed density =
       for j = 0 to dim 2 maze -1 do
          seed := (!seed * 137 + 2*i + j) mod 100;
          if !seed <  density || i = 0 || i = dim 1 maze - 1 || j = 0 || j = dim 2 maze - 1 then maze[i,j] := Wall
-         else maze[i,j] := Empty 
+         else maze[i,j] := Empty
       done
    done
   
 let insert_theseas_and_mino_in_maze maze ti tj mi mj =
    print_string "Give the row for Minotaurus initial position: " ;
    mi := read_int () ;
-   while !mi<=0 || !mi>=dim 1 maze -1 do 
+   while !mi<=0 || !mi>=dim 1 maze -1 do
       print_string "Give the row for Minotaurus initial position: " ;
-      mi := read_int ()  
+      mi := read_int ()
    done ;
-   print_string "Give the column for Minotaurus initial position: " ; 
+   print_string "Give the column for Minotaurus initial position: " ;
    mj := read_int () ;
-   while !mj<=0 || !mj>=dim 2 maze -1 do		 
-      print_string "Give the column for Minotaurus initial position: " ; 
-      mj := read_int () 
-   done ; 
-		
+   while !mj<=0 || !mj>=dim 2 maze -1 do
+      print_string "Give the column for Minotaurus initial position: " ;
+      mj := read_int ()
+   done ;
+
    maze[!mi,!mj] := Minotaurus ;
    print_string "Give the row for Theseas initial position: " ;
    ti := read_int () ;
-   while !ti<=0 || !ti>=dim 1 maze -1 do 
+   while !ti<=0 || !ti>=dim 1 maze -1 do
       print_string "Give the row for Theseas initial position: " ;
-      ti := read_int () 
+      ti := read_int ()
    done ;
-   print_string "Give the column for Theseas initial position: " ; 
+   print_string "Give the column for Theseas initial position: " ;
    tj := read_int () ;
-   while !tj<=0 || !tj>=dim 2 maze -1 do 
-      print_string "Give the column for Theseas initial position: " ; 
-      tj := read_int () 
+   while !tj<=0 || !tj>=dim 2 maze -1 do
+      print_string "Give the column for Theseas initial position: " ;
+      tj := read_int ()
    done ;
-   maze[!ti,!tj] := Theseas_InitialPos 
+   maze[!ti,!tj] := Theseas_InitialPos
 
 let rec check maze i j =
-   match !maze[i,j] with 
-     Minotaurus -> true 
+   match !maze[i,j] with
+     Minotaurus -> true
    | x          -> maze[i,j] := Thread ;
-                   if !maze[i-1,j]<>Wall && !maze[i-1,j]<>Thread && (check maze (i-1) j) 
-                   then begin maze[i-1,j] := Path ; true end 
-                   else if !maze[i,j+1]<>Wall && !maze[i,j+1]<>Thread && (check maze i (j+1)) 
-                   then begin maze[i,j+1] := Path ; true end 
-                   else if !maze[i+1,j]<>Wall && !maze[i+1,j]<>Thread && (check maze (i+1) j) 
-                   then begin maze[i+1,j] := Path ; true end 
-                   else if !maze[i,j-1]<>Wall && !maze[i,j-1]<>Thread && (check maze i (j-1)) 
-                   then begin maze[i,j-1] := Path ; true end 
+                   if !maze[i-1,j]<>Wall && !maze[i-1,j]<>Thread && (check maze (i-1) j)
+                   then begin maze[i-1,j] := Path ; true end
+                   else if !maze[i,j+1]<>Wall && !maze[i,j+1]<>Thread && (check maze i (j+1))
+                   then begin maze[i,j+1] := Path ; true end
+                   else if !maze[i+1,j]<>Wall && !maze[i+1,j]<>Thread && (check maze (i+1) j)
+                   then begin maze[i+1,j] := Path ; true end
+                   else if !maze[i,j-1]<>Wall && !maze[i,j-1]<>Thread && (check maze i (j-1))
+                   then begin maze[i,j-1] := Path ; true end
                    else false
    end
 
 let reinsert_theseas_and_mino maze ti tj mi mj =
    maze[ti,tj] := Theseas_InitialPos ;
-   maze[mi,mj] := Minotaurus 
-     
+   maze[mi,mj] := Minotaurus
+
 let main =
    print_string "\n\nGive the number of rows (eg. 20, max=50): " ;
    let rows = read_int () mod 51 in
@@ -99,9 +99,9 @@ let main =
    let mutable maze[rows,cols] in
    print_string "Enter the seed for the random maze (eg. 42): " ;
    let mutable seed in
-   seed := read_int () mod 100 ;  
+   seed := read_int () mod 100 ;
    print_string "Enter the wall density % (eg. 30): " ;
-   let density = read_int () mod 101 in 
+   let density = read_int () mod 101 in
    fill_maze maze seed density ;
    print_maze maze ;
    let mutable ti
@@ -110,7 +110,7 @@ let main =
    and mutable mj in
    insert_theseas_and_mino_in_maze maze ti tj mi mj ;
    print_maze maze;
-   if (check maze !ti !tj) then print_string "\n\n\t    Theseas has found Minotaurus! \n\n" 
+   if (check maze !ti !tj) then print_string "\n\n\t    Theseas has found Minotaurus! \n\n"
    else print_string "\n\t    Theseas cannot find Minotaurus! \n\n" ;
    reinsert_theseas_and_mino maze !ti !tj !mi !mj ;
    print_maze maze

--- a/tests/correct/mean.lla
+++ b/tests/correct/mean.lla
@@ -1,4 +1,4 @@
-let main = 
+let main =
    print_string "Give n: ";
    let n = read_int () in
    print_string "Give k: ";

--- a/tests/correct/nested.lla
+++ b/tests/correct/nested.lla
@@ -6,25 +6,25 @@ type nlist = Nil | Cons1 of int nlist | Cons2 of nlist nlist
 
 -- Concatenation of two lists
 
-let rec concat s t = 
+let rec concat s t =
    match s with
      Nil -> t
-   | Cons1 m n -> Cons1 m (concat n t) 
-   end 
+   | Cons1 m n -> Cons1 m (concat n t)
+   end
 
 --Insert an integer to a nested list
 
-let insert1 n s = 
-   s := Cons1  n !s  
+let insert1 n s =
+   s := Cons1  n !s
 
 --Insert a nested list to a nested list
 
 let insert2  n s =
-   s := Cons2  !n !s 
+   s := Cons2  !n !s
 
 --Print a nested list as a normal list
 
-let rec auxprintnl s = 
+let rec auxprintnl s =
    match s with
      Nil        ->  ()
    | Cons1  m n -> print_string " -> " ;
@@ -34,7 +34,7 @@ let rec auxprintnl s =
                    auxprintnl m ;
                    print_string " } " ;
                    auxprintnl n
-   end 
+   end
 
 let printnl s =
    match s with
@@ -42,7 +42,7 @@ let printnl s =
    | Cons1  m n -> auxprintnl s
    | Cons2  m n -> auxprintnl m;
                    auxprintnl n
-   end 
+   end
 
 --Create a normal list from a nested list
 
@@ -51,9 +51,9 @@ let rec flatten s =
      Nil        -> Nil
    | Cons1  m n	-> Cons1  m (flatten n)
    | Cons2  m n	-> concat (flatten m) (flatten n)
-   end 
+   end
 
-let main = 
+let main =
    let mutable l in
    let mutable m in
    l := Nil ;
@@ -61,7 +61,7 @@ let main =
    insert1 6 l ; insert1 5 l ; insert2 l l ;
    insert1 9 m ; insert1 7 m ;
    insert2 m l ;
-   insert1 3 l ; 
+   insert1 3 l ;
    printnl !l;
    print_string "\n" ;
    l := flatten !l;

--- a/tests/correct/prime.lla
+++ b/tests/correct/prime.lla
@@ -1,9 +1,9 @@
-let rec prime n = 
+let rec prime n =
         if n < 0 then prime (-n)
    else if n < 2 then false
    else if n = 2 then true
    else if n mod 2 = 0 then false
-   else let rec loop i = 
+   else let rec loop i =
 	   if i <= n / 2 then
 	      if n mod i = 0 then false
 	                     else loop (i+2)
@@ -21,7 +21,7 @@ let main =
    counter := 0;
    if limit >= 2 then (incr counter; print_string "2\n");
    if limit >= 3 then (incr counter; print_string "3\n");
-   let rec loop number = 
+   let rec loop number =
       if number <= limit then
       begin
          if prime (number - 1) then

--- a/tests/correct/tree.lla
+++ b/tests/correct/tree.lla
@@ -1,13 +1,11 @@
 type tree = Nil | Node of int tree tree
 
-let rec treeInsert t n = 
+let rec treeInsert t n =
    match t with
      Nil          -> Node n Nil Nil
    | Node m t1 t2 ->      if n < m then Node m (treeInsert t1 n) t2
                      else if n > m then Node m t1 (treeInsert t2 n)
-                     else t
-   end
-
+                     else t end 
 let rec treeMerge t1 t2 =
    match t1 with
      Nil            -> t2
@@ -42,9 +40,9 @@ let rec treeCount t =
    | Node n t1 t2 -> 1 + treeCount t2 + treeCount t2
    end
 
-let main = 
+let main =
    let mutable seed in
-   let next u = 
+   let next u =
       seed := (!seed * 4241 + 22) mod 9949;
       !seed in
    seed := 65;
@@ -53,7 +51,7 @@ let main =
 
    let mutable t in
    t := Nil;
-  
+
    for i = 1 to 10 do
       t := treeInsert !t (random 100)
    done;
@@ -61,7 +59,7 @@ let main =
    print_string "Initial tree: ";
    treePrint !t;
    print_string "\n";
-	
+
    let rec choose t =
       match t with
         Node n t1 t2 ->

--- a/tests/correct/whichday.lla
+++ b/tests/correct/whichday.lla
@@ -17,7 +17,7 @@
  *     newline ::= "\n"
  *
  *  where "anychar" is any character but "\n".
-  
+ *
  *  URL: http://courses.softlab.ntua.gr/compilers/
  *
  *  Nikolaos S. Papaspyrou (nickie@softlab.ntua.gr)
@@ -278,16 +278,16 @@ let find_interval mn tot lim =
    -- Successive intervals must be joined before checking that the
    -- duration is right.  These variables keep track of what we're
    -- joining.
-   
+
    let mutable joining
    and mutable d_join
    and mutable hf_join
    and mutable ht_join
    and mutable count_max_join
    and mutable count_min_join in
-   
+
    -- Check if the interval we're joining is good
-   
+
    let check_joined u =
       let result =
          if !joining then
@@ -306,13 +306,13 @@ let find_interval mn tot lim =
             begin
                print_interval (Interval !d_join !hf_join !ht_join);
                print_string ": available/not available = ";
-               print_int (tot - !count_max_join); 
+               print_int (tot - !count_max_join);
                print_string "/";
                print_int !count_max_join;
                if !count_min_join <> !count_max_join then
                begin
                   print_string " with best ";
-                  print_int (tot - !count_min_join); 
+                  print_int (tot - !count_min_join);
                   print_string "/";
                   print_int !count_min_join
                end;
@@ -348,7 +348,7 @@ let find_interval mn tot lim =
       result in
 
    -- Extend the currently joint interval
-   
+
    let extend_joining ht count =
       if debug then
       begin
@@ -372,7 +372,7 @@ let find_interval mn tot lim =
       0 in
 
    -- Walk the tree and look for solutions
-   
+
    let rec walk t =
       match t with
          Empty ->
@@ -437,10 +437,10 @@ let init_parsing =
 let parseInterval line =
 
    -- Error handling
-   
+
    let mutable errflag in
    errflag := false;
-   
+
    let error msg =
       print_string "Parse error: ";
       print_string msg;
@@ -452,12 +452,12 @@ let parseInterval line =
       errflag := true in
 
    -- Function that skips spaces
-   
+
    let skipSpaces i =
       while !line[!i] = ' ' do incr i done in
-      
+
    -- Function that parses a single day's name
-   
+
    let parseDay d i =
       let check d =
          let mutable str [10] in
@@ -477,7 +477,7 @@ let parseInterval line =
       else error "invalid day" in
 
    -- Function that parses a two digit number
-   
+
    let parseTwoDigits i n =
       let isdigit c = c >= '0' && c <= '9' in
       let digit c = int_of_char c - int_of_char '0' in
@@ -490,7 +490,7 @@ let parseInterval line =
       i := !i+2 in
 
    -- Function that parses an hour
-   
+
    let parseHour i l h =
       if l - !i < 5 then
          error "invalid hour"
@@ -510,7 +510,7 @@ let parseInterval line =
       end in
 
    -- Do the parsing
-   
+
    let mutable d
    and mutable hf
    and mutable ht
@@ -596,7 +596,7 @@ let main =
    begin
       if debug then
       begin
-         print_string "---------------------------\n";   
+         print_string "---------------------------\n";
          print_tree ()
       end;
       print_string "---------------------------\n";

--- a/tests/test_type.py
+++ b/tests/test_type.py
@@ -7,7 +7,7 @@ from compiler import ast, error, lex, parse
 
 class TestType(unittest.TestCase):
 
-    builtin_builders = ast.builtin_map.values()
+    builtin_builders = ast.builtin_types_map.values()
 
     def test_builtin_type_equality(self):
         for t in self.builtin_builders:

--- a/tests/test_type.py
+++ b/tests/test_type.py
@@ -2,12 +2,12 @@ import itertools
 import unittest
 
 import sure
-from compiler import ast, error, lex, parse, type
+from compiler import ast, error, lex, parse
 
 
 class TestType(unittest.TestCase):
 
-    builtin_builders = type.builtin_map.values()
+    builtin_builders = ast.builtin_map.values()
 
     def test_builtin_type_equality(self):
         for t in self.builtin_builders:
@@ -22,45 +22,45 @@ class TestType(unittest.TestCase):
             (typeset).should.contain(t())
 
     def test_user_defined_types(self):
-        (type.User("foo")).should.be.equal(type.User("foo"))
+        (ast.User("foo")).should.be.equal(ast.User("foo"))
 
-        (type.User("foo")).shouldnt.be.equal(type.User("bar"))
-        (type.User("foo")).shouldnt.be.equal(type.Int())
+        (ast.User("foo")).shouldnt.be.equal(ast.User("bar"))
+        (ast.User("foo")).shouldnt.be.equal(ast.Int())
 
     def test_ref_types(self):
-        footype = type.User("foo")
-        bartype = type.User("bar")
-        reffootype = type.Ref(footype)
+        footype = ast.User("foo")
+        bartype = ast.User("bar")
+        reffootype = ast.Ref(footype)
 
-        (reffootype).should.be.equal(type.Ref(footype))
+        (reffootype).should.be.equal(ast.Ref(footype))
 
         (reffootype).shouldnt.be.equal(footype)
-        (reffootype).shouldnt.be.equal(type.Ref(bartype))
+        (reffootype).shouldnt.be.equal(ast.Ref(bartype))
 
     def test_array_types(self):
-        inttype = type.Int()
-        (type.Array(inttype)).should.be.equal(type.Array(inttype))
-        (type.Array(inttype, 2)).should.be.equal(type.Array(inttype, 2))
+        inttype = ast.Int()
+        (ast.Array(inttype)).should.be.equal(ast.Array(inttype))
+        (ast.Array(inttype, 2)).should.be.equal(ast.Array(inttype, 2))
 
-        (type.Array(type.Int())).shouldnt.be.equal(type.Array(type.Float()))
-        (type.Array(inttype, 1)).shouldnt.be.equal(type.Array(inttype, 2))
+        (ast.Array(ast.Int())).shouldnt.be.equal(ast.Array(ast.Float()))
+        (ast.Array(inttype, 1)).shouldnt.be.equal(ast.Array(inttype, 2))
 
-        arrintType = type.Array(inttype)
+        arrintType = ast.Array(inttype)
         (arrintType).shouldnt.be.equal(inttype)
-        (arrintType).shouldnt.be.equal(type.User("foo"))
-        (arrintType).shouldnt.be.equal(type.Ref(inttype))
+        (arrintType).shouldnt.be.equal(ast.User("foo"))
+        (arrintType).shouldnt.be.equal(ast.Ref(inttype))
 
     def test_function_types(self):
-        intt = type.Int()
-        (type.Function(intt, intt)).should.be.equal(type.Function(intt, intt))
+        intt = ast.Int()
+        (ast.Function(intt, intt)).should.be.equal(ast.Function(intt, intt))
 
-        i2float = type.Function(type.Int(), type.Float())
-        (i2float).shouldnt.be.equal(type.Function(type.Float(), type.Int()))
+        i2float = ast.Function(ast.Int(), ast.Float())
+        (i2float).shouldnt.be.equal(ast.Function(ast.Float(), ast.Int()))
 
-        (i2float).shouldnt.be.equal(int)
-        (i2float).shouldnt.be.equal(type.User("foo"))
-        (i2float).shouldnt.be.equal(type.Ref(type.Int()))
-        (i2float).shouldnt.be.equal(type.Array(type.Int()))
+        (i2float).shouldnt.be.equal(intt)
+        (i2float).shouldnt.be.equal(ast.User("foo"))
+        (i2float).shouldnt.be.equal(ast.Ref(ast.Int()))
+        (i2float).shouldnt.be.equal(ast.Array(ast.Int()))
 
     def _process_typedef(self, typeDefListList):
         mock = error.LoggerMock()


### PR DESCRIPTION
### Parser:
- Completely delegate construction of type nodes to `ast` module.
- Move `verbose` argument from `parse` to `__init__` to allow for better logging.
- Expand grammar to allow for redefinition of built-in types. Delegate relevant error to `type` module.
### AST:
- Moved all AST nodes to `ast.py`.
- `Tdef` nodes: Replace `name` attribute (`string`) with a `type` (`User`) attribute for easier semantic analysis and better error reporting.
- Refactor and extend node hierarchy to eliminate duplication and enable "pythonic" use of AST nodes.
- Introduce generic equality. Drop `__hash__` from nameless types.
### misc:
- Beautify code.
- Fix typos and wrong comments.
- Add a bunch of docstrings.
- Make `logger`s public members.
- Purge testfiles from spurious whitespace.
