### PR TITLE
Apply 'convention over configuration' to lex/parse API.

### DIFF
--- a/compiler/lex.py
+++ b/compiler/lex.py
@@ -171,7 +171,7 @@ tokens = sum(
 )
 
 
-class _LexerBuilder:
+class _LexerFactory:
     """
     Implementation of a Llama lexer
 
@@ -508,13 +508,13 @@ class _LexerBuilder:
 class Lexer:
     """ A Llama lexer"""
 
-    # The actual lexer as returned by _LexerBuilder
+    # The actual lexer as returned by _LexerFactory
     _lexer = None
 
     # Logger used for logging events. Possibly shared with other modules.
     logger = None
 
-    # == REQUIRED METHODS (see _LexerBuilder for details) ==
+    # == REQUIRED METHODS (see _LexerFactory for details) ==
 
     token = None
     input = None
@@ -526,14 +526,18 @@ class Lexer:
 
         By default, the lexer accepts only ASCII and is optimized (i.e
         caches the lexing tables across invocations).
-        For detailed reporting on regexe construction, enable 'debug'.
+        For detailed reporting on regex construction, enable 'debug'.
         For echoing matched tokens to stdout, enable 'verbose'.
         """
-        self.logger = logger
-        self._lexer = _LexerBuilder(logger=logger, verbose=verbose)
+        if logger is None:
+            self.logger = error.LoggerMock()
+        else:
+            self.logger = logger
+
+        self._lexer = _LexerFactory(logger=logger, verbose=verbose)
         self._lexer.build(debug=debug, optimize=optimize, reflags=re.ASCII)
 
-        # Bind methods of interface to _LexerBuilder object methods.
+        # Bind methods of interface to _LexerFactory object methods.
         self.token = self._lexer.token
         self.input = self._lexer.input
         self.skip  = self._lexer.skip

--- a/compiler/lex.py
+++ b/compiler/lex.py
@@ -13,6 +13,8 @@
 # ----------------------------------------------------------------------
 """
 
+import re
+
 from ply import lex
 
 # Represent reserved words as a frozenset for fast lookup
@@ -518,11 +520,18 @@ class Lexer:
     input = None
     skip = None
 
-    def __init__(self, logger, verbose=False, **kwargs):
-        """Create a new lexer."""
+    def __init__(self, logger, debug=False, optimize=True, verbose=False):
+        """
+        Create a new lexer.
+
+        By default, the lexer accepts only ASCII and is optimized (i.e
+        caches the lexing tables across invocations).
+        For detailed reporting on regexe construction, enable 'debug'.
+        For echoing matched tokens to stdout, enable 'verbose'.
+        """
         self.logger = logger
         self._lexer = _LexerBuilder(logger=logger, verbose=verbose)
-        self._lexer.build(**kwargs)
+        self._lexer.build(debug=debug, optimize=optimize, reflags=re.ASCII)
 
         # Bind methods of interface to _LexerBuilder object methods.
         self.token = self._lexer.token

--- a/compiler/lex.py
+++ b/compiler/lex.py
@@ -576,7 +576,7 @@ class Lexer:
         return tok
 
 
-def lex(data, logger=None):
+def tokenize(data, logger=None):
     """
     Lex the given string using the default Lexer.
     Returns an iterator over the string tokens.

--- a/compiler/lex.py
+++ b/compiler/lex.py
@@ -17,6 +17,8 @@ import re
 
 from ply import lex
 
+from compiler import error
+
 # Represent reserved words as a frozenset for fast lookup
 reserved_words = frozenset('''
     and
@@ -520,17 +522,18 @@ class Lexer:
     input = None
     skip = None
 
-    def __init__(self, logger, debug=False, optimize=True, verbose=False):
+    def __init__(self, debug=False, optimize=True, logger=None, verbose=False):
         """
         Create a new lexer.
 
         By default, the lexer accepts only ASCII and is optimized (i.e
         caches the lexing tables across invocations).
+        If a 'logger' is not provided, create one.
         For detailed reporting on regex construction, enable 'debug'.
         For echoing matched tokens to stdout, enable 'verbose'.
         """
         if logger is None:
-            self.logger = error.LoggerMock()
+            self.logger = error.Logger(inputfile='<stdin>')
         else:
             self.logger = logger
 

--- a/compiler/lex.py
+++ b/compiler/lex.py
@@ -574,3 +574,13 @@ class Lexer:
         if tok is None:
             raise StopIteration
         return tok
+
+
+def lex(data, logger=None):
+    """
+    Lex the given string using the default Lexer.
+    Returns an iterator over the string tokens.
+    """
+    lexer = Lexer(logger=logger)
+    lexer.input(data)
+    return iter(lexer)

--- a/compiler/parse.py
+++ b/compiler/parse.py
@@ -13,7 +13,7 @@
 
 from ply import yacc
 
-from compiler import ast, lex, type
+from compiler import ast, error, lex, type
 
 
 def _track(p):
@@ -546,20 +546,24 @@ class Parser:
     typeTable = None
     verbose = False
 
-    def __init__(self, logger, debug=False, optimize=True, start='program',
+    def __init__(self, debug=False, logger=None, optimize=True, start='program',
                  verbose=False):
         """
         Create a parser.
 
         By default, the parser is optimized (i.e. caches LALR tables
         accross invocations).
+        If a 'logger' is not provided, create one.
         For detailed reporting on the tables construction, enable
         'debug' and check the 'parser.out' file.
         For manually specifying the initial state, modify 'start'.
         For echoing LR stack to stdout while parsing, enable 'verbose'.
         """
         self.verbose = verbose
-        self.logger = logger
+        if logger is None:
+            self.logger = error.Logger(inputfile='<stdin>')
+        else:
+            self.logger = logger
 
         # Explicitly silence warnings about unused rules when
         # starting from a state other than the default.

--- a/compiler/parse.py
+++ b/compiler/parse.py
@@ -561,26 +561,23 @@ class Parser:
         self.verbose = verbose
         self.logger = logger
 
+        # Explicitly silence warnings about unused rules when
+        # starting from a state other than the default.
+        errorlog = None if start == 'program' else yacc.NullLogger()
+        self.parser = yacc.yacc(
+            module=self,
+            errorlog=errorlog,
+            debug=debug,
+            optimize=optimize,
+            start=start
+        )
+
         if verbose:
-            self.parser = yacc.yacc(
-                module=self,
-                debug=debug,
-                optimize=optimize,
-                start=start
-            )
             self.logger.info(
                 "%s: %s: %s",
                 __name__,
                 self.__class__.__name__,
                 'parser ready'
-            )
-        else:
-            self.parser = yacc.yacc(
-                module=self,
-                debug=debug,
-                errorlog=yacc.NullLogger(),
-                optimize=optimize,
-                start=start
             )
         self.typeTable = type.Table(logger=self.logger)
 

--- a/compiler/parse.py
+++ b/compiler/parse.py
@@ -581,9 +581,11 @@ class Parser:
             )
         self.typeTable = type.Table(logger=self.logger)
 
-    def parse(self, data, lexer):
+    def parse(self, data, lexer=None):
         """
-        Parse the input and return the AST. If 'debug' is set,
-        output matched productions, state and other info to stdout.
+        Parse the input and return the AST. If a lexer is not provided,
+        create one on the fly.
         """
+        if lexer is None:
+            lexer = lex.Lexer(logger=self.logger)
         return self.parser.parse(data, lexer, debug=self.verbose)

--- a/compiler/parse.py
+++ b/compiler/parse.py
@@ -546,20 +546,41 @@ class Parser:
     typeTable = None
     verbose = False
 
-    def __init__(self, logger, verbose=False, **kwargs):
-        """Create a parser for the entire Llama grammar."""
+    def __init__(self, logger, debug=False, optimize=True, start='program',
+                 verbose=False):
+        """
+        Create a parser.
+
+        By default, the parser is optimized (i.e. caches LALR tables
+        accross invocations).
+        For detailed reporting on the tables construction, enable
+        'debug' and check the 'parser.out' file.
+        For manually specifying the initial state, modify 'start'.
+        For echoing LR stack to stdout while parsing, enable 'verbose'.
+        """
         self.verbose = verbose
         self.logger = logger
+
         if verbose:
-            self.parser = yacc.yacc(module=self, **kwargs)
-        else:
-            self.parser = yacc.yacc(module=self, errorlog=yacc.NullLogger(), **kwargs)
-        if verbose:
+            self.parser = yacc.yacc(
+                module=self,
+                debug=debug,
+                optimize=optimize,
+                start=start
+            )
             self.logger.info(
                 "%s: %s: %s",
                 __name__,
                 self.__class__.__name__,
                 'parser ready'
+            )
+        else:
+            self.parser = yacc.yacc(
+                module=self,
+                debug=debug,
+                errorlog=yacc.NullLogger(),
+                optimize=optimize,
+                start=start
             )
         self.typeTable = type.Table(logger=self.logger)
 

--- a/compiler/parse.py
+++ b/compiler/parse.py
@@ -593,3 +593,12 @@ class Parser:
         if lexer is None:
             lexer = lex.Lexer(logger=self.logger)
         return self.parser.parse(data, lexer, debug=self.verbose)
+
+
+def parse(data, logger=None):
+    """
+    Parse the given string using the default Parser.
+    Returns the AST.
+    """
+    parser = Parser(logger=logger)
+    return parser.parse(data)

--- a/main.py
+++ b/main.py
@@ -12,7 +12,6 @@
 import argparse
 import collections
 import logging
-import re
 import sys
 
 from compiler import lex, parse, error
@@ -80,7 +79,7 @@ def mk_cli_parser():
             Report any parsing errors to stderr.
             ''',
         action='store_true',
-        default=0
+        default=False
     )
     return cli_parser
 
@@ -121,32 +120,11 @@ def main():
     OPTS['lexer_verbose'] = args.lexer_verbose
     OPTS['parser_verbose'] = args.parser_verbose
 
-    # Create an error logger
-    logger = error.Logger(
-        inputfile=OPTS['input'],
-        level=logging.DEBUG
-    )
+    logger = error.Logger(inputfile=OPTS['input'],level=logging.DEBUG)
 
-    # Make a lexer. By default, the lexer accepts only ASCII
-    # and is optimized (i.e caches the lexing tables across
-    # invocations).
-    lexer = lex.Lexer(
-        lextab='lextab',
-        logger=logger,
-        optimize=1,
-        reflags=re.ASCII,
-        verbose=OPTS['lexer_verbose'])
+    lexer = lex.Lexer(logger=logger, verbose=OPTS['lexer_verbose'])
 
-    # Make a parser. By default, the parser is optimized
-    # (i.e. caches LALR tables accross invocations). A 'parser.out' file
-    # is created every time the tables are regenerated unless 'debug'
-    # is set to 0.
-    parser = parse.Parser(
-        logger=logger,
-        optimize=1,
-        start='program',
-        verbose=OPTS['parser_verbose']
-    )
+    parser = parse.Parser(logger=logger, verbose=OPTS['parser_verbose'])
 
     # Stop here if this a dry run.
     if OPTS['prepare']:
@@ -157,10 +135,7 @@ def main():
     data = read_program(OPTS['input'])
 
     # Parse and construct the AST.
-    ast = parser.parse(
-        data=data,
-        lexer=lexer
-    )
+    ast = parser.parse(data=data, lexer=lexer)
 
     # On bad program, terminate with error.
     if not logger.success:

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -25,17 +25,11 @@ class TestLexer(unittest.TestCase):
         mock.success.should.be.ok
 
     def _assert_lex_success(self, input):
-        mock = error.LoggerMock()
-        lexer = lex.Lexer(logger=mock)
-        lexer.input(input)
-        list(lexer)  # Force lexing
+        l, mock = self._lex_data(input)
         mock.success.should.be.ok
 
     def _assert_lex_failure(self, input):
-        mock = error.LoggerMock()
-        lexer = lex.Lexer(logger=mock)
-        lexer.input(input)
-        list(lexer)  # Force lexing
+        l, mock = self._lex_data(input)
         mock.success.shouldnt.be.ok
 
     def test_init(self):

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -10,11 +10,8 @@ from compiler import error, lex
 class TestLexer(unittest.TestCase):
     def _lex_data(self, input):
         mock = error.LoggerMock()
-        lexer = lex.Lexer(logger=mock)
-        lexer.input(input)
-        token_list = list(lexer)
-
-        return (token_list, mock)
+        tokens = lex.tokenize(input, logger=mock)
+        return list(tokens), mock
 
     def _assert_individual_token(self, input, expected_type, expected_value):
         l, mock = self._lex_data(input)

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -4,7 +4,7 @@ import unittest
 
 import sure
 
-from compiler import lex, error
+from compiler import error, lex
 
 
 class TestLexer(unittest.TestCase):

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -32,6 +32,11 @@ class TestLexer(unittest.TestCase):
         l, mock = self._lex_data(input)
         mock.success.shouldnt.be.ok
 
+    def test_tokenize(self):
+        list(lex.tokenize("")).should.be.equal([])
+        mock = error.LoggerMock()
+        list(lex.tokenize("", mock)).should.be.equal([])
+
     def test_init(self):
         mock = error.LoggerMock()
         lexer = lex.Lexer(logger=mock)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -16,8 +16,6 @@ class TestParser(unittest.TestCase):
     def _parse(self, data, start='program'):
         mock = error.LoggerMock()
 
-        lexer = lex.Lexer(logger=mock)
-
         # memoization
         try:
             parser = self.parsers[start]
@@ -28,10 +26,7 @@ class TestParser(unittest.TestCase):
                 start=start
             )
 
-        tree = parser.parse(
-            data=data,
-            lexer=lexer
-        )
+        tree = parser.parse(data=data)
 
         return tree
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2,7 +2,7 @@ import unittest
 
 import sure
 
-from compiler import parse, lex, error, ast, type
+from compiler import ast, error, lex, parse, type
 
 
 class TestParser(unittest.TestCase):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -30,6 +30,11 @@ class TestParser(unittest.TestCase):
 
         return tree
 
+    def test_parse(self):
+        parse.parse("").should.be.equal(ast.Program([]))
+        mock = error.LoggerMock()
+        parse.parse("", logger=mock).should.be.equal(ast.Program([]))
+
     def test_empty_program(self):
        self._parse("").should.be.equal(ast.Program([]))
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -16,7 +16,7 @@ class TestParser(unittest.TestCase):
     def _parse(self, data, start='program'):
         mock = error.LoggerMock()
 
-        lexer = lex.Lexer(logger=mock, optimize=1)
+        lexer = lex.Lexer(logger=mock)
 
         # memoization
         try:
@@ -24,9 +24,8 @@ class TestParser(unittest.TestCase):
         except:
             parser = self.parsers[start] = parse.Parser(
                 logger=mock,
-                optimize=0,
-                start=start,
-                debug=0
+                optimize=False,
+                start=start
             )
 
         tree = parser.parse(

--- a/tests/test_type.py
+++ b/tests/test_type.py
@@ -64,8 +64,8 @@ class TestType(unittest.TestCase):
 
     def _process_typedef(self, typeDefListList):
         mock = error.LoggerMock()
-        lexer = lex.Lexer(logger=mock, optimize=1)
-        parser = parse.Parser(logger=mock, optimize=1)
+        lexer = lex.Lexer(logger=mock)
+        parser = parse.Parser(logger=mock)
         parser.parse(data=typeDefListList, lexer=lexer)
         return parser.logger.success
 

--- a/tests/test_type.py
+++ b/tests/test_type.py
@@ -64,9 +64,8 @@ class TestType(unittest.TestCase):
 
     def _process_typedef(self, typeDefListList):
         mock = error.LoggerMock()
-        parser = parse.Parser(logger=mock)
-        parser.parse(data=typeDefListList)
-        return parser.logger.success
+        parse.parse(typeDefListList, logger=mock)
+        return mock.success
 
     def test_type_process(self):
         right_testcases = (

--- a/tests/test_type.py
+++ b/tests/test_type.py
@@ -64,9 +64,8 @@ class TestType(unittest.TestCase):
 
     def _process_typedef(self, typeDefListList):
         mock = error.LoggerMock()
-        lexer = lex.Lexer(logger=mock)
         parser = parse.Parser(logger=mock)
-        parser.parse(data=typeDefListList, lexer=lexer)
+        parser.parse(data=typeDefListList)
         return parser.logger.success
 
     def test_type_process(self):

--- a/tests/test_type.py
+++ b/tests/test_type.py
@@ -2,7 +2,7 @@ import itertools
 import unittest
 
 import sure
-from compiler import ast, error, lex, parse
+from compiler import ast, error, parse
 
 
 class TestType(unittest.TestCase):


### PR DESCRIPTION
### Lex:
- PLY arguments are now explicitly stated (and part of interface).
- Build own `logger` if one is not provided.
- Rename `_LexerBuilder` to `_LexerFactory` to follow semantics.
- Add `tokenize` function at module level to enable hassle-free lexing.
### Parse:
- Silence PLY errors/warnings when building a parser with non-default initial state.
- Build own `logger` if one is not provided.
- Build own `lexer` if one is not provided.
- Add `parse` function at module level to enable hassle-free parsing.
### Tests:
- Add tests for module-level functions.
- Use the default objects/arguments of the new API.
- Do some DRY & pep8-ing.

Fix #22.
