### PR TITLE
Add start argument to parse.parse.

### DIFF
--- a/compiler/parse.py
+++ b/compiler/parse.py
@@ -626,10 +626,11 @@ class Parser:
         return self.parser.parse(data, lexer, debug=self.verbose)
 
 
-def parse(data, logger=None):
+def parse(data, start='program', logger=None):
     """
-    Parse the given string using the default Parser.
-    Returns the AST.
+    Parse the given string using the default Parser. Return the AST.
+    For parsing using a specific subgrammar, set 'start' appropriately.
+    For customised error reporting, provide a 'logger'.
     """
-    parser = Parser(logger=logger)
+    parser = Parser(logger=logger, start=start)
     return parser.parse(data)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -18,9 +18,15 @@ class TestParser(unittest.TestCase, parser_db.ParserDB):
         cls.yfunc = cls._parse("let y = 2", "letdef")
 
     def test_parse(self):
-        parse.parse("").should.equal(ast.Program([]))
+        p1 = parse.Parser()
+        (parse.parse("")).should.equal(p1.parse(""))
+
         mock = error.LoggerMock()
-        parse.parse("", logger=mock).should.equal(ast.Program([]))
+        p2 = parse.Parser(logger=mock)
+        parse.parse("", logger=mock).should.equal(p2.parse(""))
+
+        p3 = parse.Parser(start='type')
+        (parse.parse("int", start='type')).should.equal(p3.parse("int"))
 
     def test_empty_program(self):
         self._parse("").should.equal(ast.Program([]))


### PR DESCRIPTION
Fix #51.
### Parse:
- `parse.parse` now accepts `start` argument.
### Parse test:
- Test behaviour of `parse.parse` against behaviour of `p.parse` where `p` is a properly intstantiated `parse.Parser`.
