### PR TITLE
Check for conflicts in grammar during `make prepare`.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ static:
 
 prepare:
 	$(PYTHON) main.py $(PREPARE_FLAGS)
+	$(BINPATH)/ctest.sh
 
 cleanaux:
 	$(RM) aux*.py

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PYTHON=python3
-PREPARE_FLAG=--prepare
+PREPARE_FLAGS=--prepare -pd
 OPT=-OO
 SOURCEFILES=main.py ./compiler/*.py
 BINPATH=./bin
@@ -26,7 +26,7 @@ static:
 	pylint -E $(SOURCEFILES)
 
 prepare:
-	$(PYTHON) main.py $(PREPARE_FLAG)
+	$(PYTHON) main.py $(PREPARE_FLAGS)
 
 cleanaux:
 	$(RM) aux*.py

--- a/bin/ctest.sh
+++ b/bin/ctest.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# Check that no conflicts arised during grammar processing.
+! grep "conflict" --silent parser.out

--- a/main.py
+++ b/main.py
@@ -81,6 +81,16 @@ def mk_cli_parser():
         action='store_true',
         default=False
     )
+
+    cli_parser.add_argument(
+        '-pd',
+        '--parser_debug',
+        help='''
+            Force dumping grammar processing to file 'parser.out'.
+            ''',
+        action='store_true',
+        default=False
+    )
     return cli_parser
 
 
@@ -119,12 +129,17 @@ def main():
     OPTS['prepare'] = args.prepare
     OPTS['lexer_verbose'] = args.lexer_verbose
     OPTS['parser_verbose'] = args.parser_verbose
+    OPTS['parser_debug'] = args.parser_debug
 
     logger = error.Logger(inputfile=OPTS['input'], level=logging.DEBUG)
 
     lexer = lex.Lexer(logger=logger, verbose=OPTS['lexer_verbose'])
 
-    parser = parse.Parser(logger=logger, verbose=OPTS['parser_verbose'])
+    parser = parse.Parser(
+            debug=OPTS['parser_debug'],
+            logger=logger,
+            verbose=OPTS['parser_verbose']
+    )
 
     # Stop here if this a dry run.
     if OPTS['prepare']:


### PR DESCRIPTION
Fix #35.
### Main:
- Add `parser_debug` switch to llama CLI.
### Makefile:
- Dump LALR processing to `parser.out` during `make prepare`.
- Add script for testing for conflicts after preparing LR tables.
