### PR TITLE
Simplify Makefile. Split `all` and `test` targets.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ python:
 install:
   - "pip install -r requirements.txt"
 # command to run tests
-script: make test
+script: make

--- a/Makefile
+++ b/Makefile
@@ -16,10 +16,10 @@ test:
 	make -B unittest
 	make -B functionaltest
 
-unittest: cleanmain prepare $(BINPATH)/utest.sh
+unittest: $(BINPATH)/utest.sh
 	$(BINPATH)/utest.sh
 
-functionaltest: cleanmain prepare $(BINPATH)/ftest.sh
+functionaltest: $(BINPATH)/ftest.sh
 	$(BINPATH)/ftest.sh
 
 static:

--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,7 @@ all: clean prepare test
 beauty:
 	pep8 --ignore=E221 $(SOURCEFILES) $(TESTPATH)
 
-test:
-	make -B unittest
-	make -B functionaltest
+test: unittest functionaltest
 
 unittest: $(BINPATH)/utest.sh
 	$(BINPATH)/utest.sh

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ TESTPATH=./tests/
 
 .PHONY: beauty clean cleanaux functionaltest prepare static test unittest
 
-all: test
+all: clean prepare test
 
 beauty:
 	pep8 --ignore=E221 $(SOURCEFILES) $(TESTPATH)


### PR DESCRIPTION
### Makefile:
- No recursive calls to `make`.
- No forced cleaning before `unittest` and `functionaltest`.
### Travis CI:
- Update testsuite command.
