### PR TITLE
Separate loggers for each module. Make logger initialization consistent. Beautify main module. Add API tests of type module.

### DIFF
--- a/compiler/error.py
+++ b/compiler/error.py
@@ -87,7 +87,7 @@ class Logger(LoggerInterface):
     # The logger instance, as constructed by the logging module
     _logger = None
 
-    def __init__(self, inputfile, level=logging.WARNING):
+    def __init__(self, inputfile="<stdin>", level=logging.WARNING):
         """Create a new logger for the llama compiler."""
         self._logger = logging.getLogger('llama%d' % Logger._instances)
         Logger._instances += 1

--- a/compiler/lex.py
+++ b/compiler/lex.py
@@ -533,7 +533,7 @@ class Lexer:
         For echoing matched tokens to stdout, enable 'verbose'.
         """
         if logger is None:
-            self.logger = error.Logger(inputfile='<stdin>')
+            self.logger = error.Logger()
         else:
             self.logger = logger
 

--- a/compiler/parse.py
+++ b/compiler/parse.py
@@ -564,7 +564,7 @@ class Parser:
         """
         self.verbose = verbose
         if logger is None:
-            self.logger = error.Logger(inputfile='<stdin>')
+            self.logger = error.Logger()
         else:
             self.logger = logger
 

--- a/compiler/type.py
+++ b/compiler/type.py
@@ -94,7 +94,7 @@ class Validator:
     def __init__(self, logger=None):
         """Create a new Validator."""
         if logger is None:
-            self.logger = error.Logger(inputfile='<stdin>')
+            self.logger = error.Logger()
         else:
             self.logger = logger
 
@@ -129,7 +129,7 @@ class Table:
     def __init__(self, logger=None):
         """Initialize a new Table."""
         if logger is None:
-            self.logger = error.Logger(inputfile="<stdin>")
+            self.logger = error.Logger()
         else:
             self.logger = logger
 

--- a/compiler/type.py
+++ b/compiler/type.py
@@ -126,9 +126,12 @@ class Table:
     # Logger used for logging events. Possibly shared with other modules.
     logger = None
 
-    def __init__(self, logger):
+    def __init__(self, logger=None):
         """Initialize a new Table."""
-        self.logger = logger
+        if logger is None:
+            self.logger = error.Logger(inputfile="<stdin>")
+        else:
+            self.logger = logger
 
         # Dictionary of types seen so far. Builtin types always available.
         # Values : list of constructors which the type defines

--- a/main.py
+++ b/main.py
@@ -131,13 +131,14 @@ def main():
     OPTS['parser_verbose'] = args.parser_verbose
     OPTS['parser_debug'] = args.parser_debug
 
-    logger = error.Logger(inputfile=OPTS['input'], level=logging.DEBUG)
-
-    lexer = lex.Lexer(logger=logger, verbose=OPTS['lexer_verbose'])
+    lexer = lex.Lexer(
+        logger=error.Logger(inputfile=OPTS['input'], level=logging.DEBUG),
+        verbose=OPTS['lexer_verbose']
+    )
 
     parser = parse.Parser(
         debug=OPTS['parser_debug'],
-        logger=logger,
+        logger=error.Logger(inputfile=OPTS['input'], level=logging.DEBUG),
         verbose=OPTS['parser_verbose']
     )
 

--- a/main.py
+++ b/main.py
@@ -150,11 +150,11 @@ def main():
     # Get some input.
     data = read_program(OPTS['input'])
 
-    # Parse and construct the AST.
+    # Lex, parse and construct the AST.
     ast = parser.parse(data=data, lexer=lexer)
 
-    # On bad program, terminate with error.
-    if not logger.success:
+    # On lexing/parsing error, abort further compilation.
+    if not (lexer.logger.success or parser.logger.success):
         sys.exit(1)
 
 if __name__ == '__main__':

--- a/main.py
+++ b/main.py
@@ -25,70 +25,70 @@ def mk_cli_parser():
     """Generate a cli parser for the llama compiler."""
 
     cli_parser = argparse.ArgumentParser(
-        description='Llama compiler.',
-        epilog='Use at your own RISC.'
+        description="Llama compiler.",
+        epilog="Use at your own RISC."
     )
 
     cli_parser.add_argument(
-        '-i',
-        '--input',
-        help='''
-            The input file. If ommitted, input is read from stdin.
-            ''',
-        nargs='?',
+        "-i",
+        "--input",
+        help="""\
+            The input file. If ommitted, input is read from stdin.\
+            """,
+        nargs="?",
         const=None,
-        default='<stdin>'
+        default="<stdin>"
     )
 
     cli_parser.add_argument(
-        '-o',
-        '--output',
-        help='''
-            The output file. If ommitted, it defaults to a.out.
-            ''',
-        nargs='?',
-        default='a.out'
+        "-o",
+        "--output",
+        help="""\
+            The output file. If ommitted, it defaults to a.out.\
+            """,
+        nargs="?",
+        default="a.out"
     )
 
     cli_parser.add_argument(
-        '-pp',
-        '--prepare',
-        help='''
-            Build the lexing and parsing tables and exit.
-            ''',
-        action='store_true',
+        "-pp",
+        "--prepare",
+        help="""\
+            Build the lexing and parsing tables and exit.\
+            """,
+        action="store_true",
         default=False
     )
 
     cli_parser.add_argument(
-        '-lv',
-        '--lexer_verbose',
-        help='''
-            Output the lexed tokens along with their file position to stdout.
-            Report any lexing errors to stderr.
-            ''',
-        action='store_true',
+        "-lv",
+        "--lexer_verbose",
+        help="""\
+            Output the lexed tokens along with their file position to stdout.\
+            Report any lexing errors to stderr.\
+            """,
+        action="store_true",
         default=False
     )
 
     cli_parser.add_argument(
-        '-pv',
-        '--parser_verbose',
-        help='''
-            Output the parser state during parsing (token, item, etc).
-            Report any parsing errors to stderr.
-            ''',
-        action='store_true',
+        "-pv",
+        "--parser_verbose",
+        help="""\
+            Output the parser state during parsing (token, item, etc).\
+            Report any parsing errors to stderr.\
+            """,
+        action="store_true",
         default=False
     )
 
     cli_parser.add_argument(
-        '-pd',
-        '--parser_debug',
-        help='''
-            Force dumping grammar processing to file 'parser.out'.
-            ''',
-        action='store_true',
+        "-pd",
+        "--parser_debug",
+        help="""\
+            Force dumping grammar processing to file 'parser.out'.\
+            """,
+        action="store_true",
         default=False
     )
     return cli_parser
@@ -99,7 +99,7 @@ def read_program(input_file):
     Read input from file or stdin (if a file is not provided).
     Return read program as a single string.
     """
-    if input_file == '<stdin>':
+    if input_file == "<stdin>":
         sys.stdout.write("Reading from stdin (type <EOF> to end):\n")
         sys.stdout.flush()
         data = sys.stdin.read()
@@ -110,7 +110,7 @@ def read_program(input_file):
             file.close()
         except IOError:
             sys.exit(
-                'Could not open file %s for reading. Aborting.'
+                "Could not open file %s for reading. Aborting."
                 % input_file
             )
     return data
@@ -124,31 +124,31 @@ def main():
     args = parser.parse_args()
 
     # Store options & switches in global dict.
-    OPTS['input'] = args.input
-    OPTS['output'] = args.output
-    OPTS['prepare'] = args.prepare
-    OPTS['lexer_verbose'] = args.lexer_verbose
-    OPTS['parser_verbose'] = args.parser_verbose
-    OPTS['parser_debug'] = args.parser_debug
+    OPTS["input"] = args.input
+    OPTS["output"] = args.output
+    OPTS["prepare"] = args.prepare
+    OPTS["lexer_verbose"] = args.lexer_verbose
+    OPTS["parser_verbose"] = args.parser_verbose
+    OPTS["parser_debug"] = args.parser_debug
 
     lexer = lex.Lexer(
-        logger=error.Logger(inputfile=OPTS['input'], level=logging.DEBUG),
-        verbose=OPTS['lexer_verbose']
+        logger=error.Logger(inputfile=OPTS["input"], level=logging.DEBUG),
+        verbose=OPTS["lexer_verbose"]
     )
 
     parser = parse.Parser(
-        debug=OPTS['parser_debug'],
-        logger=error.Logger(inputfile=OPTS['input'], level=logging.DEBUG),
-        verbose=OPTS['parser_verbose']
+        debug=OPTS["parser_debug"],
+        logger=error.Logger(inputfile=OPTS["input"], level=logging.DEBUG),
+        verbose=OPTS["parser_verbose"]
     )
 
     # Stop here if this a dry run.
-    if OPTS['prepare']:
-        print('Finished generating lexer and parser tables. Exiting...')
+    if OPTS["prepare"]:
+        print("Finished generating lexer and parser tables. Exiting...")
         return
 
     # Get some input.
-    data = read_program(OPTS['input'])
+    data = read_program(OPTS["input"])
 
     # Lex, parse and construct the AST.
     ast = parser.parse(data=data, lexer=lexer)
@@ -157,5 +157,5 @@ def main():
     if not (lexer.logger.success or parser.logger.success):
         sys.exit(1)
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/tests/test_type.py
+++ b/tests/test_type.py
@@ -20,6 +20,20 @@ class TestType(unittest.TestCase, parser_db.ParserDB):
         except type.LlamaInvalidTypeError:
             pass
 
+    @staticmethod
+    def test_table_init():
+        t1 = type.Table()
+
+        logger = error.LoggerMock()
+        t2 = type.Table(logger=logger)
+
+    @staticmethod
+    def test_validator_init():
+        t1 = type.Validator()
+
+        logger = error.LoggerMock()
+        t2 = type.Validator(logger=logger)
+
     @classmethod
     def _process_typedef(cls, typedefListList):
         mock = error.LoggerMock()

--- a/tests/test_type.py
+++ b/tests/test_type.py
@@ -4,7 +4,8 @@ from compiler import ast, error, type
 from tests import parser_db
 
 
-class TestType(unittest.TestCase, parser_db.ParserDB):
+class TestTypeAPI(unittest.TestCase, parser_db.ParserDB):
+    """Test the API of the type module."""
 
     def test_bad_type_error(self):
         try:
@@ -33,6 +34,10 @@ class TestType(unittest.TestCase, parser_db.ParserDB):
 
         logger = error.LoggerMock()
         t2 = type.Validator(logger=logger)
+
+
+class TestTable(unittest.TestCase, parser_db.ParserDB):
+    """Test the Table's processing of type definitions."""
 
     @classmethod
     def _process_typedef(cls, typedefListList):
@@ -95,6 +100,10 @@ class TestType(unittest.TestCase, parser_db.ParserDB):
         for case in wrong_testcases:
             tree = self._parse(case)
             proc.when.called_with(tree).should.throw(error)
+
+
+class TestValidator(unittest.TestCase, parser_db.ParserDB):
+    """Test the Validator's functionality."""
 
     @staticmethod
     def _is_array(t):

--- a/tests/test_type.py
+++ b/tests/test_type.py
@@ -6,6 +6,20 @@ from tests import parser_db
 
 class TestType(unittest.TestCase, parser_db.ParserDB):
 
+    def test_bad_type_error(self):
+        try:
+            raise type.LlamaBadTypeError()
+            self.fail()
+        except type.LlamaBadTypeError:
+            pass
+
+    def test_invalid_type_error(self):
+        try:
+            raise type.LlamaInvalidTypeError()
+            self.fail()
+        except type.LlamaInvalidTypeError:
+            pass
+
     @classmethod
     def _process_typedef(cls, typedefListList):
         mock = error.LoggerMock()

--- a/tests/test_type.py
+++ b/tests/test_type.py
@@ -31,8 +31,8 @@ class TestType(unittest.TestCase, parser_db.ParserDB):
             """
         )
 
-        for typedef in right_testcases:
-            tree = self._parse(typedef)
+        for case in right_testcases:
+            tree = self._parse(case)
             proc.when.called_with(tree).shouldnt.throw(error)
 
         wrong_testcases = (
@@ -64,8 +64,8 @@ class TestType(unittest.TestCase, parser_db.ParserDB):
             """
         )
 
-        for typedef in wrong_testcases:
-            tree = self._parse(typedef)
+        for case in wrong_testcases:
+            tree = self._parse(case)
             proc.when.called_with(tree).should.throw(error)
 
     def _is_array(self, t):
@@ -81,8 +81,8 @@ class TestType(unittest.TestCase, parser_db.ParserDB):
             "array [*, *] of int"
         )
 
-        for type in right_testcases:
-            tree = self._parse(type, 'type')
+        for case in right_testcases:
+            tree = self._parse(case, 'type')
             self._is_array(tree).should.be.true
 
         wrong_testcases = (
@@ -91,8 +91,8 @@ class TestType(unittest.TestCase, parser_db.ParserDB):
             "int -> int",
         )
 
-        for type in wrong_testcases:
-            tree = self._parse(type, 'type')
+        for case in wrong_testcases:
+            tree = self._parse(case, 'type')
             self._is_array(tree).should.be.false
 
     def _validate(self, t):
@@ -132,8 +132,8 @@ class TestType(unittest.TestCase, parser_db.ParserDB):
             "(int -> int) -> int"
         )
 
-        for typedef in right_testcases:
-            tree = self._parse(typedef, 'type')
+        for case in right_testcases:
+            tree = self._parse(case, 'type')
             proc.when.called_with(tree).shouldnt.throw(error)
 
         wrong_testcases = (
@@ -147,6 +147,6 @@ class TestType(unittest.TestCase, parser_db.ParserDB):
             "int -> (int -> array of int)"
         )
 
-        for typedef in wrong_testcases:
-            tree = self._parse(typedef, 'type')
+        for case in wrong_testcases:
+            tree = self._parse(case, 'type')
             proc.when.called_with(tree).should.throw(error)

--- a/tests/test_type.py
+++ b/tests/test_type.py
@@ -96,7 +96,8 @@ class TestType(unittest.TestCase, parser_db.ParserDB):
             tree = self._parse(case)
             proc.when.called_with(tree).should.throw(error)
 
-    def _is_array(self, t):
+    @staticmethod
+    def _is_array(t):
         return type.Validator.is_array(t)
 
     def test_isarray(self):

--- a/tests/test_type.py
+++ b/tests/test_type.py
@@ -27,6 +27,7 @@ class TestTypeAPI(unittest.TestCase, parser_db.ParserDB):
 
         logger = error.LoggerMock()
         t2 = type.Table(logger=logger)
+        t2.should.have.property("logger").being(logger)
 
     @staticmethod
     def test_validator_init():
@@ -34,6 +35,7 @@ class TestTypeAPI(unittest.TestCase, parser_db.ParserDB):
 
         logger = error.LoggerMock()
         t2 = type.Validator(logger=logger)
+        t2.should.have.property("logger").being(logger)
 
 
 class TestTable(unittest.TestCase, parser_db.ParserDB):


### PR DESCRIPTION
Fix #29.
### Main:
- Explicitly test for lexing and parsing success.
- Separate `logger`s for lexer and parser.
- Beautify usage message.
- Use consistent quotes.
### Error:
- Error: DRY default `inputfile` argument.
### Type:
- `Table`: Create own logger if one is not provided.
### Type test:
- Fix name clash of `type` module and `type` variable.
- Test module API.
- Separate tests in classes.
