### PR TITLE
Refactor and test lex API. Simplify standalone use of lex module. Fix couple of bugs. Beautify test code.

### DIFF
--- a/compiler/lex.py
+++ b/compiler/lex.py
@@ -521,14 +521,15 @@ class Lexer:
         self._lexer.build(debug=debug, optimize=optimize, reflags=re.ASCII)
 
         # Bind methods of interface to _LexerFactory object methods.
-        self.token = self._lexer.token
         self.input = self._lexer.input
         self.skip  = self._lexer.skip
+        self.token = self._lexer.token
 
     def tokenize(self, data):
-        """Lex the given string, Return an iterator over the string tokens."""
+        """
+        Lex the given string. Return an iterator over the string tokens.
+        """
         self.input(data)
-        self.logger.clear()
         return iter(self)
 
     # == EXPORT POSITION ATTRIBUTES ==

--- a/compiler/lex.py
+++ b/compiler/lex.py
@@ -530,8 +530,17 @@ class Lexer:
             self.logger = logger
         self.verbose = verbose
 
-        self._lexer = _LexerFactory(logger=self.logger, verbose=verbose)
-        self._lexer.build(debug=debug, optimize=optimize, reflags=re.ASCII)
+        self._setup_inner_lexer()
+
+    def _setup_inner_lexer(self):
+        """Create a new inner lexer and bind it to the Lexer object."""
+
+        self._lexer = _LexerFactory(logger=self.logger, verbose=self.verbose)
+        self._lexer.build(
+            debug=self.debug,
+            optimize=self.optimize,
+            reflags=re.ASCII
+        )
 
     # == ITERATOR INTERFACE ==
 

--- a/compiler/lex.py
+++ b/compiler/lex.py
@@ -525,6 +525,11 @@ class Lexer:
         self.input = self._lexer.input
         self.skip  = self._lexer.skip
 
+    def tokenize(self, data):
+        """Lex the given string, Return an iterator over the string tokens."""
+        self.input(data)
+        return iter(self)
+
     # == EXPORT POSITION ATTRIBUTES ==
 
     @property
@@ -555,8 +560,7 @@ def tokenize(data, logger=None):
     Return an iterator over the string tokens.
     """
     lexer = Lexer(logger=logger)
-    lexer.input(data)
-    return lexer
+    return lexer.tokenize(data)
 
 
 def quiet_tokenize(data):

--- a/compiler/lex.py
+++ b/compiler/lex.py
@@ -557,3 +557,12 @@ def tokenize(data, logger=None):
     lexer = Lexer(logger=logger)
     lexer.input(data)
     return lexer
+
+
+def quiet_tokenize(data):
+    """
+    Lex the given string using the default Lexer.
+    Return an iterator over the string tokens.
+    Explicitly silence errors/warnings.
+    """
+    return tokenize(data, logger=error.LoggerMock())

--- a/compiler/lex.py
+++ b/compiler/lex.py
@@ -214,15 +214,6 @@ class _LexerFactory:
         self.logger = logger
         self.verbose = verbose
 
-    def reset(self):
-        """Reset the lexer's state."""
-        self.bol = -1
-        self.level = 0
-        self.logger.clear()
-        self.lexer.begin('INITIAL')
-        self.lexer.lexpos = 0
-        self.lexer.lineno = 1
-
     # == REQUIRED METHODS ==
 
     def build(self, **kwargs):
@@ -274,9 +265,8 @@ class _LexerFactory:
         return tok
 
     def input(self, lexdata):
-        """Feed the lexer with input and reset the state."""
+        """Feed the lexer with input."""
         self.lexer.input(lexdata)
-        self.reset()
 
     def skip(self, value=1):
         """Skip 'value' characters in the input string."""

--- a/compiler/lex.py
+++ b/compiler/lex.py
@@ -528,6 +528,7 @@ class Lexer:
     def tokenize(self, data):
         """Lex the given string, Return an iterator over the string tokens."""
         self.input(data)
+        self.logger.clear()
         return iter(self)
 
     # == EXPORT POSITION ATTRIBUTES ==

--- a/compiler/lex.py
+++ b/compiler/lex.py
@@ -213,13 +213,6 @@ class _LexerFactory:
         """
         self.logger = logger
         self.verbose = verbose
-        if self.verbose:
-            self.logger.info(
-                "%s: %s: %s",
-                __name__,
-                self.__class__.__name__,
-                'wrapper initialized'
-            )
 
     # == REQUIRED METHODS ==
 
@@ -231,13 +224,6 @@ class _LexerFactory:
         or attributes of the wrapper object are accessed.
         """
         self.lexer = lex.lex(module=self, **kwargs)
-        if self.verbose:
-            self.logger.info(
-                "%s: %s: %s",
-                __name__,
-                self.__class__.__name__,
-                'lexer ready'
-            )
 
     # A wrapper around the function of the inner lexer
     def token(self):
@@ -538,13 +524,6 @@ class Lexer:
         self.token = self._lexer.token
         self.input = self._lexer.input
         self.skip  = self._lexer.skip
-        if verbose:
-            self.logger.info(
-                "%s: %s: %s",
-                __name__,
-                self.__class__.__name__,
-                'lexer ready'
-            )
 
     # == EXPORT POSITION ATTRIBUTES ==
 

--- a/compiler/lex.py
+++ b/compiler/lex.py
@@ -516,12 +516,6 @@ class Lexer:
     # Logger used for logging events. Possibly shared with other modules.
     logger = None
 
-    # == REQUIRED METHODS (see _LexerFactory for details) ==
-
-    token = None
-    input = None
-    skip = None
-
     def __init__(self, debug=False, optimize=True, logger=None, verbose=False):
         """
         Create a new lexer.

--- a/compiler/lex.py
+++ b/compiler/lex.py
@@ -552,8 +552,8 @@ class Lexer:
 def tokenize(data, logger=None):
     """
     Lex the given string using the default Lexer.
-    Returns an iterator over the string tokens.
+    Return an iterator over the string tokens.
     """
     lexer = Lexer(logger=logger)
     lexer.input(data)
-    return iter(lexer)
+    return lexer

--- a/compiler/lex.py
+++ b/compiler/lex.py
@@ -530,8 +530,6 @@ class Lexer:
             self.logger = logger
         self.verbose = verbose
 
-        self._setup_inner_lexer()
-
     def _setup_inner_lexer(self):
         """Create a new inner lexer and bind it to the Lexer object."""
 
@@ -556,7 +554,8 @@ class Lexer:
     # == PUBLIC API ==
 
     def input(self, data):
-        """Feed the lexer with input."""
+        """Feed the lexer with input and prepare for tokenizing."""
+        self._setup_inner_lexer()
         self._lexer.input(data)
 
     def skip(self, amount):

--- a/compiler/lex.py
+++ b/compiler/lex.py
@@ -214,6 +214,15 @@ class _LexerFactory:
         self.logger = logger
         self.verbose = verbose
 
+    def reset(self):
+        """Reset the lexer's state."""
+        self.bol = -1
+        self.level = 0
+        self.logger.clear()
+        self.lexer.begin('INITIAL')
+        self.lexer.lexpos = 0
+        self.lexer.lineno = 1
+
     # == REQUIRED METHODS ==
 
     def build(self, **kwargs):
@@ -265,8 +274,9 @@ class _LexerFactory:
         return tok
 
     def input(self, lexdata):
-        """Feed the lexer with input."""
+        """Feed the lexer with input and reset the state."""
         self.lexer.input(lexdata)
+        self.reset()
 
     def skip(self, value=1):
         """Skip 'value' characters in the input string."""

--- a/compiler/lex.py
+++ b/compiler/lex.py
@@ -533,10 +533,34 @@ class Lexer:
         self._lexer = _LexerFactory(logger=self.logger, verbose=verbose)
         self._lexer.build(debug=debug, optimize=optimize, reflags=re.ASCII)
 
-        # Bind methods of interface to _LexerFactory object methods.
-        self.input = self._lexer.input
-        self.skip  = self._lexer.skip
-        self.token = self._lexer.token
+    # == ITERATOR INTERFACE ==
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        tok = self.token()
+        if tok is None:
+            raise StopIteration
+        return tok
+
+    # == PUBLIC API ==
+
+    def input(self, data):
+        """Feed the lexer with input."""
+        self._lexer.input(data)
+
+    def skip(self, amount):
+        """Skip the lexer 'amount' characters forward."""
+        if self._lexer is None:
+            raise Exception("Cannot skip over empty data.")
+        self._lexer.skip(amount)
+
+    def token(self):
+        """Skip the lexer 'amount' characters forward."""
+        if self._lexer is None:
+            raise Exception("Cannot tokenize from empty data.")
+        return self._lexer.token()
 
     def tokenize(self, data):
         """
@@ -556,17 +580,6 @@ class Lexer:
     def lineno(self):
         """Return current line of input"""
         return self._lexer.lexer.lineno
-
-    # == ITERATOR INTERFACE ==
-
-    def __iter__(self):
-        return self
-
-    def __next__(self):
-        tok = self.token()
-        if tok is None:
-            raise StopIteration
-        return tok
 
 
 def tokenize(data, logger=None):

--- a/compiler/lex.py
+++ b/compiler/lex.py
@@ -522,10 +522,13 @@ class Lexer:
         For detailed reporting on regex construction, enable 'debug'.
         For echoing matched tokens to stdout, enable 'verbose'.
         """
+        self.debug = debug
+        self.optimize = optimize
         if logger is None:
             self.logger = error.Logger()
         else:
             self.logger = logger
+        self.verbose = verbose
 
         self._lexer = _LexerFactory(logger=self.logger, verbose=verbose)
         self._lexer.build(debug=debug, optimize=optimize, reflags=re.ASCII)

--- a/compiler/lex.py
+++ b/compiler/lex.py
@@ -527,7 +527,7 @@ class Lexer:
         else:
             self.logger = logger
 
-        self._lexer = _LexerFactory(logger=logger, verbose=verbose)
+        self._lexer = _LexerFactory(logger=self.logger, verbose=verbose)
         self._lexer.build(debug=debug, optimize=optimize, reflags=re.ASCII)
 
         # Bind methods of interface to _LexerFactory object methods.

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -31,6 +31,9 @@ class TestLexer(unittest.TestCase):
         mock = error.LoggerMock()
         list(lex.tokenize("", mock)).should.equal([])
 
+    def test_quiet_tokenize(self):
+        list(lex.quiet_tokenize("")).should.equal([])
+
     def test_iterator(self):
         mock = error.LoggerMock()
         lexer = lex.Lexer(logger=mock)

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -31,6 +31,13 @@ class TestLexer(unittest.TestCase):
         mock = error.LoggerMock()
         list(lex.tokenize("", mock)).should.equal([])
 
+    def test_iterator(self):
+        mock = error.LoggerMock()
+        lexer = lex.Lexer(logger=mock)
+        lexer.input("foo")
+        i = iter(lexer)
+        next(lexer)
+
     def test_init(self):
         mock = error.LoggerMock()
         lexer = lex.Lexer(logger=mock)

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -40,8 +40,11 @@ class TestLexer(unittest.TestCase):
 
         logger = error.LoggerMock()
         l2 = lex.Lexer(logger=logger)
-        tokens2 = list(l2.tokenize(""))
+        tokens2 = list(l2.tokenize("(*"))
         tokens2.should.equal([])
+        l2.logger.success.should.equal.false
+        tokens3 = list(lex.tokenize(""))
+        tokens3.should.equal([])
         l2.logger.success.should.equal.true
 
     @staticmethod

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -46,9 +46,9 @@ class TestLexer(unittest.TestCase):
 
     @staticmethod
     def _lex_data(input):
-        logger = error.LoggerMock()
-        tokens = lex.tokenize(input, logger=logger)
-        return list(tokens), logger
+        lexer = lex.Lexer(logger=error.LoggerMock())
+        tokens = list(lexer.tokenize(input))
+        return tokens, lexer.logger
 
     def _assert_individual_token(self, input, expected_type, expected_value):
         tokens, logger = self._lex_data(input)

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -36,16 +36,15 @@ class TestLexer(unittest.TestCase):
         l1 = lex.Lexer()
         tokens1 = list(l1.tokenize(""))
         tokens1.should.equal([])
-        l1.logger.success.should.equal.true
+        l1.logger.success.should.be.true
 
-        logger = error.LoggerMock()
-        l2 = lex.Lexer(logger=logger)
+        l2 = lex.Lexer(logger=error.LoggerMock())
         tokens2 = list(l2.tokenize("(*"))
         tokens2.should.equal([])
-        l2.logger.success.should.equal.false
-        tokens3 = list(lex.tokenize(""))
+        l2.logger.success.should.be.false
+        tokens3 = list(l2.tokenize(""))
         tokens3.should.equal([])
-        l2.logger.success.should.equal.true
+        l2.logger.success.should.be.true
 
     @staticmethod
     def _lex_data(input):

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -4,7 +4,22 @@ import unittest
 from compiler import error, lex
 
 
+class TestModuleAPI(unittest.TestCase):
+    """Test the API of the lex module."""
+
+    def test_tokenize(self):
+        list(lex.tokenize("")).should.equal([])
+
+        mock = error.LoggerMock()
+        list(lex.tokenize("", mock)).should.equal([])
+
+    def test_quiet_tokenize(self):
+        list(lex.quiet_tokenize("")).should.equal([])
+
+
 class TestLexer(unittest.TestCase):
+    """Test the API of the Lexer class."""
+
     def _lex_data(self, input):
         mock = error.LoggerMock()
         tokens = lex.tokenize(input, logger=mock)
@@ -25,14 +40,6 @@ class TestLexer(unittest.TestCase):
     def _assert_lex_failure(self, input):
         _, mock = self._lex_data(input)
         mock.success.should.be.false
-
-    def test_tokenize(self):
-        list(lex.tokenize("")).should.equal([])
-        mock = error.LoggerMock()
-        list(lex.tokenize("", mock)).should.equal([])
-
-    def test_quiet_tokenize(self):
-        list(lex.quiet_tokenize("")).should.equal([])
 
     def test_iterator(self):
         mock = error.LoggerMock()

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -84,6 +84,7 @@ class TestLexerAPI(unittest.TestCase):
         tokens2 = list(l2.tokenize("(*"))
         tokens2.should.equal([])
         l2.logger.success.should.be.false
+        l2.logger.clear()
         tokens3 = list(l2.tokenize(""))
         tokens3.should.equal([])
         l2.logger.success.should.be.true

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -32,6 +32,48 @@ class TestLexerAPI(unittest.TestCase):
     """Test the API of the Lexer class."""
 
     @staticmethod
+    def test_init():
+        lexer1 = lex.Lexer()
+
+        logger = error.LoggerMock()
+        lexer2 = lex.Lexer(
+            logger=logger,
+            debug=False,
+            optimize=True,
+            verbose=False
+        )
+        lexer2.should.have.property("debug").being(False)
+        lexer2.should.have.property("logger").being(logger)
+        lexer2.should.have.property("optimize").being(True)
+        lexer2.should.have.property("verbose").being(False)
+
+    @staticmethod
+    def test_input():
+        lexer = lex.Lexer()
+        lexer.input("foo")
+
+    @staticmethod
+    def test_skip():
+        lexer = lex.Lexer()
+        lexer.skip.when.called_with(1).should.throw(Exception)
+        lexer.input("foo")
+        lexer.skip(1)
+
+    @staticmethod
+    def test_token():
+        lexer = lex.Lexer()
+        lexer.token.when.called.should.throw(Exception)
+        lexer.input("foo")
+        t = lexer.token()
+
+    @staticmethod
+    def test_iterator():
+        lexer = lex.Lexer()
+        lexer.input("foo")
+        i = iter(lexer)
+        next(lexer)
+
+    @staticmethod
     def test_tokenize():
         l1 = lex.Lexer()
         tokens1 = list(l1.tokenize(""))
@@ -71,17 +113,6 @@ class TestLexerRules(unittest.TestCase):
     def _assert_lex_failure(self, input):
         _, logger = self._lex_data(input)
         logger.success.should.be.false
-
-    def test_iterator(self):
-        lexer = lex.Lexer(logger=error.LoggerMock())
-        lexer.input("foo")
-        i = iter(lexer)
-        next(lexer)
-
-    def test_init(self):
-        logger = error.LoggerMock()
-        lexer = lex.Lexer(logger=logger)
-        lexer.should.have.property("logger").being.equal(logger)
 
     def test_empty(self):
         tokens, logger = self._lex_data("")

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -7,20 +7,45 @@ from compiler import error, lex
 class TestModuleAPI(unittest.TestCase):
     """Test the API of the lex module."""
 
-    def test_tokenize(self):
-        list(lex.tokenize("")).should.equal([])
+    @staticmethod
+    def test_tokenize():
+        l1 = lex.Lexer()
+        tokens1 = list(lex.tokenize(""))
+        tokens2 = list(l1.tokenize(""))
+        tokens1.should.equal(tokens2)
 
         mock = error.LoggerMock()
-        list(lex.tokenize("", mock)).should.equal([])
+        l2 = lex.Lexer(logger=mock)
+        tokens3 = list(lex.tokenize(""))
+        tokens4 = list(l2.tokenize(""))
+        tokens3.should.equal(tokens4)
 
-    def test_quiet_tokenize(self):
-        list(lex.quiet_tokenize("")).should.equal([])
+    @staticmethod
+    def test_quiet_tokenize():
+        l1 = lex.Lexer(logger=error.LoggerMock())
+        tokens1 = list(lex.quiet_tokenize(""))
+        tokens2 = list(l1.tokenize(""))
+        tokens1.should.equal(tokens2)
 
 
 class TestLexer(unittest.TestCase):
     """Test the API of the Lexer class."""
 
-    def _lex_data(self, input):
+    @staticmethod
+    def test_tokenize():
+        l1 = lex.Lexer()
+        tokens1 = list(l1.tokenize(""))
+        tokens1.should.equal([])
+        l1.logger.success.should.equal.true
+
+        logger = error.LoggerMock()
+        l2 = lex.Lexer(logger=logger)
+        tokens2 = list(l2.tokenize(""))
+        tokens2.should.equal([])
+        l2.logger.success.should.equal.true
+
+    @staticmethod
+    def _lex_data(input):
         logger = error.LoggerMock()
         tokens = lex.tokenize(input, logger=logger)
         return list(tokens), logger

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -28,7 +28,7 @@ class TestModuleAPI(unittest.TestCase):
         tokens1.should.equal(tokens2)
 
 
-class TestLexer(unittest.TestCase):
+class TestLexerAPI(unittest.TestCase):
     """Test the API of the Lexer class."""
 
     @staticmethod
@@ -45,6 +45,10 @@ class TestLexer(unittest.TestCase):
         tokens3 = list(l2.tokenize(""))
         tokens3.should.equal([])
         l2.logger.success.should.be.true
+
+
+class TestLexerRules(unittest.TestCase):
+    """Test the Lexer's coverage of Llama vocabulary."""
 
     @staticmethod
     def _lex_data(input):

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -21,42 +21,41 @@ class TestLexer(unittest.TestCase):
     """Test the API of the Lexer class."""
 
     def _lex_data(self, input):
-        mock = error.LoggerMock()
-        tokens = lex.tokenize(input, logger=mock)
-        return list(tokens), mock
+        logger = error.LoggerMock()
+        tokens = lex.tokenize(input, logger=logger)
+        return list(tokens), logger
 
     def _assert_individual_token(self, input, expected_type, expected_value):
-        tokens, mock = self._lex_data(input)
+        tokens, logger = self._lex_data(input)
         tokens.should.have.length_of(1)
         tok = tokens[0]
         tok.type.shouldnt.be.different_of(expected_type)
         tok.value.should.equal(expected_value)
-        mock.success.should.be.true
+        logger.success.should.be.true
 
     def _assert_lex_success(self, input):
-        _, mock = self._lex_data(input)
-        mock.success.should.be.true
+        _, logger = self._lex_data(input)
+        logger.success.should.be.true
 
     def _assert_lex_failure(self, input):
-        _, mock = self._lex_data(input)
-        mock.success.should.be.false
+        _, logger = self._lex_data(input)
+        logger.success.should.be.false
 
     def test_iterator(self):
-        mock = error.LoggerMock()
-        lexer = lex.Lexer(logger=mock)
+        lexer = lex.Lexer(logger=error.LoggerMock())
         lexer.input("foo")
         i = iter(lexer)
         next(lexer)
 
     def test_init(self):
-        mock = error.LoggerMock()
-        lexer = lex.Lexer(logger=mock)
-        lexer.should.have.property("logger").being.equal(mock)
+        logger = error.LoggerMock()
+        lexer = lex.Lexer(logger=logger)
+        lexer.should.have.property("logger").being.equal(logger)
 
     def test_empty(self):
-        tokens, mock = self._lex_data("")
+        tokens, logger = self._lex_data("")
         tokens.should.be.empty
-        mock.success.should.be.true
+        logger.success.should.be.true
 
     def test_keywords(self):
         for input_program in lex.reserved_words:


### PR DESCRIPTION
### Lex:
- Add `tokenize` and `quiet_tokenize` for ease of use.
- Factor inner lexer setup in separate method.
- [bugfix] Explicitly bind `logger` of `_LexerFactory` to `logger` of `Lexer`.
- [bugfix] Renew inner lexer on each data input.
- Drop debugging info; `verbose` should serve only one purpose.
- Improve API of `Lexer`. Throw `Exception` when requesting infeasible operations.
- Store `debug`, `optimize` and `verbose` status in `Lexer`.
- Improve docstrings and beautify code.
### Lex test:
- Expand and groom API testing using TDD.
- Cleaning `logger` after faulty input is user's responsibility.
- Split tests in many classes.
- Fix typos and beautify code.
