### PR TITLE
Redesign SymbolTable. Expand AST hierarchy.

### DIFF
--- a/compiler/ast.py
+++ b/compiler/ast.py
@@ -74,7 +74,8 @@ class Def(Node):
 
 class NameNode(Node):
     """
-    A node with a user-defined name.
+    A node with a user-defined name that possibly requires
+    scope-aware disambiguation or checking.
     Provides basic hashing functionality.
     """
     name = None
@@ -119,7 +120,7 @@ class LetDef(ListNode):
         self.isRec = isRec
 
 
-class FunctionDef(Def, ListNode):
+class FunctionDef(Def, NameNode, ListNode):
     def __init__(self, name, list, body, type=None):
         self.name = name
         self.list = list
@@ -127,7 +128,7 @@ class FunctionDef(Def, ListNode):
         self.type = type
 
 
-class Param(DataNode):
+class Param(DataNode, NameNode):
     def __init__(self, name, type=None):
         self.name = name
         self.type = type
@@ -146,13 +147,13 @@ class UnaryExpression(Expression):
         self.operand = operand
 
 
-class ConstructorCallExpression(Expression, ListNode):
+class ConstructorCallExpression(Expression, ListNode, NameNode):
     def __init__(self, name, list):
         self.name = name
         self.list = list
 
 
-class ArrayExpression(Expression, ListNode):
+class ArrayExpression(Expression, ListNode, NameNode):
     def __init__(self, name, list):
         self.name = name
         self.list = list
@@ -164,12 +165,12 @@ class ConstExpression(Expression):
         self.value = value
 
 
-class ConidExpression(Expression):
+class ConidExpression(Expression, NameNode):
     def __init__(self, name):
         self.name = name
 
 
-class GenidExpression(Expression):
+class GenidExpression(Expression, NameNode):
     def __init__(self, name):
         self.name = name
 
@@ -179,7 +180,7 @@ class DeleteExpression(Expression):
         self.expr = expr
 
 
-class DimExpression(Expression):
+class DimExpression(Expression, NameNode):
     def __init__(self, name, dimension=1):
         self.name = name
         self.dimension = dimension
@@ -194,7 +195,7 @@ class ForExpression(Expression):
         self.isDown = isDown
 
 
-class FunctionCallExpression(Expression, ListNode):
+class FunctionCallExpression(Expression, ListNode, NameNode):
     def __init__(self, name, list):
         self.name = name
         self.list = list
@@ -225,13 +226,13 @@ class Clause(Node):
         self.expr = expr
 
 
-class Pattern(ListNode):
+class Pattern(ListNode, NameNode):
     def __init__(self, name, list):
         self.name = name
         self.list = list
 
 
-class GenidPattern(Node):
+class GenidPattern(NameNode):
     def __init__(self, name):
         self.name = name
 
@@ -247,13 +248,13 @@ class WhileExpression(Expression):
         self.body = body
 
 
-class VariableDef(Def):
+class VariableDef(Def, NameNode):
     def __init__(self, name, type=None):
         self.name = name
         self.type = type
 
 
-class ArrayVariableDef(VariableDef):
+class ArrayVariableDef(VariableDef, NameNode):
     def __init__(self, name, dimensions, type=None):
         self.name = name
         self.dimensions = dimensions

--- a/compiler/ast.py
+++ b/compiler/ast.py
@@ -120,10 +120,10 @@ class LetDef(ListNode):
         self.isRec = isRec
 
 
-class FunctionDef(Def, NameNode, ListNode):
-    def __init__(self, name, list, body, type=None):
+class FunctionDef(Def, NameNode):
+    def __init__(self, name, params, body, type=None):
         self.name = name
-        self.list = list
+        self.params = params
         self.body = body
         self.type = type
 

--- a/compiler/ast.py
+++ b/compiler/ast.py
@@ -119,10 +119,10 @@ class LetDef(ListNode):
         self.isRec = isRec
 
 
-class FunctionDef(Def):
-    def __init__(self, name, params, body, type=None):
+class FunctionDef(Def, ListNode):
+    def __init__(self, name, list, body, type=None):
         self.name = name
-        self.params = params
+        self.list = list
         self.body = body
         self.type = type
 

--- a/compiler/symbol.py
+++ b/compiler/symbol.py
@@ -78,9 +78,8 @@ class SymbolTable:
     # the same identifier, appearing at increasing scope depth.
     hash_table = defaultdict(list)
 
-    def __init__(self, logger):
+    def __init__(self):
         """Make a new symbol table and insert the library namespace."""
-        self.logger = logger
         self._insert_library_symbols()
 
     def _insert_library_symbols(self):

--- a/compiler/symbol.py
+++ b/compiler/symbol.py
@@ -1,3 +1,4 @@
+"""
 # ----------------------------------------------------------------------
 # symbol.py
 #
@@ -7,6 +8,7 @@
 # Authors: Nick Korasidis <Renelvon@gmail.com>
 #          Dimitris Koutsoukos <dim.kou.shmmy@gmail.com>
 # ----------------------------------------------------------------------
+"""
 
 from collections import defaultdict
 
@@ -147,7 +149,8 @@ class SymbolTable:
         return None
 
     def _find_identifier_in_current_scope(self, identifier):
-        assert self.cur_scope, 'No scope to check for identifier.'
+        """Find an identifier in the current scope."""
+        assert self.cur_scope, 'No scope to search.'
 
         entry = self.hash_table[identifier][-1]
 
@@ -168,7 +171,6 @@ class SymbolTable:
 
         if guard:
             entry = self._find_identifier_in_current_scope(new_entry.identifier)
-
             if entry is not None:
                 self._logger.error(
                     # FIXME: Meaningful line?

--- a/compiler/symbol.py
+++ b/compiler/symbol.py
@@ -60,7 +60,7 @@ class SymbolTable:
 
     def __init__(self, logger):
         """Make a new symbol table and insert the library namespace."""
-        self._logger = logger
+        self.logger = logger
         self._insert_library_symbols()
 
     def _insert_library_symbols(self):
@@ -142,9 +142,10 @@ class SymbolTable:
                 return entry
 
         if guard:
-            self._logger.error(
+            self.logger.error(
                 # FIXME: Meaningful line?
-                "Unknown identifier: %s" % identifier
+                "error: Unknown identifier: %s",
+                identifier
             )
         return None
 
@@ -170,11 +171,12 @@ class SymbolTable:
         new_id = new_entry.identifier
 
         if guard:
-            entry = self._find_identifier_in_current_scope(new_entry.identifier)
+            entry = self._find_identifier_in_current_scope(new_id)
             if entry is not None:
-                self._logger.error(
+                self.logger.error(
                     # FIXME: Meaningful line?
-                    "Duplicate identifier: %s" % new_entry.identifier
+                    "error: Duplicate identifier: %s",
+                    new_id
                     # TODO: Show line of previous declaration
                 )
                 # TODO: Raise some kind of exception here.

--- a/compiler/symbol.py
+++ b/compiler/symbol.py
@@ -28,9 +28,7 @@ class SymbolTable:
         # Used for fast lookup and sanity-checking.
         scope = None
 
-        @property
-        def identifier(self):
-            return self.node.name
+        # Entry has an implicit identifier: node.name
 
         def __init__(self, node, scope):
             """Create a new symbol table entry from a NameNode."""
@@ -116,9 +114,9 @@ class SymbolTable:
         """Close current scope in symbol table. Cleanup scope entries."""
         old_scope = self._pop_scope()
         for entry in old_scope.entries:
-            eid = entry.identifier
-            assert self.hash_table[eid], 'Identifier %s not found' % eid
-            self.hash_table[entry.identifier].pop()
+            ename = entry.node.name
+            assert self.hash_table[ename], 'Identifier %s not found' % ename
+            self.hash_table[ename].pop()
         return old_scope
 
 #     def insert_scope(self, scope):
@@ -126,7 +124,7 @@ class SymbolTable:
 #         assert self.cur_scope, 'No scope to merge into.'
 #         for entry in scope.entries:
 #             entry.scope = self.cur_scope
-#             self.hash_table[entry.identifier].append(entry)
+#             self.hash_table[entry.node.name].append(entry)
 #             self.cur_scope.entries.append(entry)
 #
 
@@ -154,15 +152,17 @@ class SymbolTable:
             )
         return None
 
-    def _find_identifier_in_current_scope(self, identifier):
-        """Find an identifier in the current scope."""
+    def _find_name_in_current_scope(self, name):
+        """
+        Lookup a name in the current scope.
+        If lookup succeeds, return the entry, None otherwise.
+        """
         assert self.cur_scope, 'No scope to search.'
 
-        entry = self.hash_table[identifier][-1]
+        entry = self.hash_table[name][-1]
 
         if entry.scope.nesting != self.nesting:
             return None
-
         return entry
 
     def insert_symbol(self, node, guard=False):

--- a/compiler/symbol.py
+++ b/compiler/symbol.py
@@ -146,13 +146,11 @@ class SymbolTable:
 #             self.cur_scope.entries.append(entry)
 #
 
-    def lookup_symbol(self, node, lookup_all=False, guard=False):
+    def lookup_symbol(self, node, lookup_all=False):
         """
         Lookup name of 'node' in current scope.
-        If 'lookup_all' is True, perform lookup in all scopes.
-        If 'guard' is True, alert if name is absent from
-        checked scope(s).
         If lookup succeeds, return the stored node, None otherwise.
+        If 'lookup_all' is set, perform lookup in all scopes.
         """
 
         ename = node.name
@@ -165,14 +163,12 @@ class SymbolTable:
             if entry is not None:
                 return entry.node
 
-        if guard:
-            self.logger.error(
-                "%d:%d: error: Unknown identifier: %s",
-                node.lineno,
-                node.lexpos,
-                ename
-            )
-            # TODO: Raise an exception here.
+        self.logger.error(
+            "%d:%d: error: Unknown identifier: %s",
+            node.lineno,
+            node.lexpos,
+            ename
+        )
         return None
 
     def _find_name_in_current_scope(self, name):

--- a/compiler/symbol.py
+++ b/compiler/symbol.py
@@ -38,14 +38,27 @@ class Scope:
     A scope of the symbol table. Contains a list of entries,
     knows its nesting level and can be optionally hidden from lookup.
     """
-    entries = []
-    visible = True
-    nesting = None
 
     def __init__(self, entries, visible, nesting):
         """Make a new scope."""
+
+        # List of names defined in the scope.
+        # Mainly used for clean-up upon closing the scope.
         self.entries = entries
+
+        # If the scope is not 'visible' then its entries should be hidden
+        # from name lookup. In Llama, scopes are by default hidden upon
+        # their creation. A name defined in a hidden scope cannot be used
+        # until after the scope is made visible. This allows proper name
+        # shadowing: the shadowed name's value can be correctly referenced
+        # when initializing the shadowing names.
+        # Exceptions: Some scopes are visible from the moment of their
+        # creation, as for example those introduced by a 'let rec'.
+        # This is necessary for implementing recursive definitions.
         self.visible = visible
+
+        # Nesting level within the SymbolTable.
+        # TODO: Should this be a read-only attribute?
         self.nesting = nesting
 
 

--- a/compiler/symbol.py
+++ b/compiler/symbol.py
@@ -76,7 +76,7 @@ class SymbolTable:
 
     # Each hashtable entry is a list containing symbols with
     # the same identifier, appearing at increasing scope depth.
-    hash_table = defaultdict(list)
+    _hash_table = defaultdict(list)
 
     def __init__(self):
         """Make a new symbol table and insert the library namespace."""
@@ -132,8 +132,8 @@ class SymbolTable:
         old_scope = self._pop_scope()
         for entry in old_scope.entries:
             ename = entry.node.name
-            assert self.hash_table[ename], 'Identifier %s not found' % ename
-            self.hash_table[ename].pop()
+            assert self._hash_table[ename], 'Identifier %s not found' % ename
+            self._hash_table[ename].pop()
         return old_scope
 
 #     def insert_scope(self, scope):
@@ -141,7 +141,7 @@ class SymbolTable:
 #         assert self.cur_scope, 'No scope to merge into.'
 #         for entry in scope.entries:
 #             entry.scope = self.cur_scope
-#             self.hash_table[entry.node.name].append(entry)
+#             self._hash_table[entry.node.name].append(entry)
 #             self.cur_scope.entries.append(entry)
 #
 
@@ -154,13 +154,13 @@ class SymbolTable:
 
         ename = node.name
         if lookup_all:
-            for entry in reversed(self.hash_table[ename]):
+            for entry in reversed(self._hash_table[ename]):
                 if entry.scope.visible:
                     return entry.node
 
         assert self.cur_scope, 'No scope to search.'
         try:
-            entry = self.hash_table[ename][-1]
+            entry = self._hash_table[ename][-1]
         except (KeyError, IndexError):
             # NOTE: Using defaultdict means KeyError never happens.
             return None
@@ -184,5 +184,5 @@ class SymbolTable:
             raise RedefIdentifierError(node, prev)
 
         new_entry = self._Entry(node, self.cur_scope)
-        self.hash_table[node.name].append(new_entry)
+        self._hash_table[node.name].append(new_entry)
         self.cur_scope.entries.append(new_entry)

--- a/compiler/symbol.py
+++ b/compiler/symbol.py
@@ -14,44 +14,45 @@ from collections import defaultdict
 
 from compiler import ast
 
-class Entry:
-    """An entry of the symbol table."""
-    # Reference to the ast node that the entry represents.
-    # The node should contain the lineno and lexpos attributes.
-    node = None
-
-    # Reference to the symbol table scope containing the entry.
-    # Used for fast lookup and sanity-checking.
-    scope = None
-
-    @property
-    def identifier(self):
-        return self.node.name
-
-    def __init__(self, node, scope):
-        """Create a new symbol table entry from a NameNode."""
-        self.node = node
-        self.scope = scope
-
-
-class Scope:
-    """
-    A scope of the symbol table. Contains a list of entries,
-    knows its nesting level and can be optionally hidden from lookup.
-    """
-    entries = []
-    visible = True
-    nesting = None
-
-    def __init__(self, entries, visible, nesting):
-        """Make a new scope."""
-        self.entries = entries
-        self.visible = visible
-        self.nesting = nesting
-
 
 class SymbolTable:
     """A fully Pythonic symbol table for Llama."""
+
+    class _Entry:
+        """An entry of the symbol table."""
+        # Reference to the ast node that the entry represents.
+        # The node should contain the lineno and lexpos attributes.
+        node = None
+
+        # Reference to the symbol table scope containing the entry.
+        # Used for fast lookup and sanity-checking.
+        scope = None
+
+        @property
+        def identifier(self):
+            return self.node.name
+
+        def __init__(self, node, scope):
+            """Create a new symbol table entry from a NameNode."""
+            self.node = node
+            self.scope = scope
+
+
+    class _Scope:
+        """
+        A scope of the symbol table. Contains a list of entries,
+        knows its nesting level and can be optionally hidden from lookup.
+        """
+        entries = []
+        visible = True
+        nesting = None
+
+        def __init__(self, entries, visible, nesting):
+            """Make a new scope."""
+            self.entries = entries
+            self.visible = visible
+            self.nesting = nesting
+
 
     _scopes = []
     nesting = 0       # Inv.: nesting == len(scopes)
@@ -71,14 +72,14 @@ class SymbolTable:
         # TODO: Dump library namespace here as a tuple of virtual AST nodes.
         lib_namespace = tuple()
 
-        lib_scope = Scope(
+        lib_scope = self._Scope(
             entries=[],
             visible=True,
             nesting=self.nesting
         )
 
         for node in lib_namespace:
-            entry = Entry(node, lib_scope)
+            entry = self._Entry(node, lib_scope)
             lib_scope.entries.append(entry)
 
         self._push_scope(lib_scope)
@@ -102,7 +103,7 @@ class SymbolTable:
 
     def open_scope(self):
         """Open a new scope in the symbol table."""
-        new_scope = Scope(
+        new_scope = self._Scope(
             entries=[],
             visible=True,
             nesting=self.nesting + 1

--- a/compiler/symbol.py
+++ b/compiler/symbol.py
@@ -163,12 +163,6 @@ class SymbolTable:
             if entry is not None:
                 return entry.node
 
-        self.logger.error(
-            "%d:%d: error: Unknown identifier: %s",
-            node.lineno,
-            node.lexpos,
-            ename
-        )
         return None
 
     def _find_name_in_current_scope(self, name):
@@ -197,16 +191,7 @@ class SymbolTable:
 
         entry = self._find_identifier_in_current_scope(new_name)
         if entry is not None:
-            self.logger.error(
-                "%d:%d: error: Redefining identifier '%s' in same scope"
-                "\tPrevious definition: %d:%d",
-                node.lineno,
-                node.lexpos,
-                node.name,
-                entry.node.lineno,
-                entry.node.lexpos
-            )
-            # TODO: Raise some kind of exception here.
+            raise RedefIdentifierError(node, entry.node)
 
         self.hash_table[new_entry.identifier].append(new_entry)
         self.cur_scope.entries.append(new_entry)

--- a/compiler/symbol.py
+++ b/compiler/symbol.py
@@ -157,11 +157,10 @@ class SymbolTable:
             for entry in reversed(self.hash_table[ename]):
                 if entry.scope.visible:
                     return entry.node
-        else:
-            entry = self._find_name_in_current_scope(ename)
-            if entry is not None:
-                return entry.node
 
+        entry = self._find_name_in_current_scope(ename)
+        if entry is not None:
+            return entry.node
         return None
 
     def _find_name_in_current_scope(self, name):

--- a/compiler/symbol.py
+++ b/compiler/symbol.py
@@ -156,27 +156,26 @@ class SymbolTable:
 
         return entry
 
-    def insert_symbol(self, identifier, guard=False):
+    def insert_symbol(self, node, guard=False):
         """
         Insert a new symbol in the current scope.
         If 'guard' is True, alert if an alias is already present.
         """
         assert self.cur_scope, 'No scope to insert into.'
 
+        new_entry = self._Entry(node, self.cur_scope)
+        new_id = new_entry.identifier
+
         if guard:
-            entry = self._find_identifier_in_current_scope(identifier)
+            entry = self._find_identifier_in_current_scope(new_entry.identifier)
 
             if entry is not None:
                 self._logger.error(
                     # FIXME: Meaningful line?
-                    "Duplicate identifier: %s" % identifier
+                    "Duplicate identifier: %s" % new_entry.identifier
                     # TODO: Show line of previous declaration
                 )
+                # TODO: Raise some kind of exception here.
 
-                return entry
-
-        new_entry = Entry(identifier=identifier, scope=self.cur_scope)
-        self.hash_table[identifier].append(new_entry)
+        self.hash_table[new_entry.identifier].append(new_entry)
         self.cur_scope.entries.append(new_entry)
-
-        return new_entry

--- a/compiler/symbol.py
+++ b/compiler/symbol.py
@@ -33,18 +33,14 @@ class Scope:
     knows its nesting level and can be optionally hidden from lookup.
     """
     entries = []
-    hidden = False
+    visible = True
     nesting = None
 
-    def __init__(self, entries, hidden, nesting):
+    def __init__(self, entries, visible, nesting):
         """Make a new scope."""
         self.entries = entries
-        self.hidden = hidden
+        self.visible = visible
         self.nesting = nesting
-
-    def hide_scope(self, hidden=True):
-        """Hide visibility of scope."""
-        self.hidden = hidden
 
 
 class SymbolTable:
@@ -69,7 +65,7 @@ class SymbolTable:
 
         lib_scope = Scope(
             entries=[],
-            hidden=False,
+            visible=True,
             nesting=self.nesting
         )
 
@@ -100,7 +96,7 @@ class SymbolTable:
         """Open a new scope in the symbol table."""
         new_scope = Scope(
             entries=[],
-            hidden=False,
+            visible=True,
             nesting=self.nesting + 1
         )
 
@@ -134,7 +130,7 @@ class SymbolTable:
         """
         if lookup_all:
             for entry in reversed(self.hash_table[identifier]):
-                if not entry.scope.hidden:
+                if entry.scope.visible:
                     return entry
         else:
             entry = self._find_identifier_in_current_scope(identifier)

--- a/compiler/symbol.py
+++ b/compiler/symbol.py
@@ -15,6 +15,24 @@ from collections import defaultdict
 from compiler import ast
 
 
+class SymbolError(Exception):
+    """
+    Exception thrown on symbol table error.
+    Carries the offending ast node(s).
+    This class is only meant as an interface.
+    Only specific sublcasses should be instantiated.
+    """
+    pass
+
+
+class RedefIdentifierError(SymbolError):
+    """Exception thrown on redefining identifier in same scope."""
+
+    def __init__(self, node, prev):
+        self.node = node
+        self.prev = prev
+
+
 class SymbolTable:
     """A fully Pythonic symbol table for Llama."""
 

--- a/compiler/symbol.py
+++ b/compiler/symbol.py
@@ -149,8 +149,9 @@ class SymbolTable:
 
         if guard:
             self.logger.error(
-                # FIXME: Meaningful line?
-                "error: Unknown identifier: %s",
+                "%d:%d: error: Unknown identifier: %s",
+                node.lineno,
+                node.lexpos,
                 ename
             )
             # TODO: Raise an exception here.
@@ -175,7 +176,7 @@ class SymbolTable:
         If 'guard' is True, alert if an alias is already present.
         """
         assert self.cur_scope, 'No scope to insert into.'
-        assert isinstance(node, ast.NameNode), 'Node is not a NameNode'
+        assert isinstance(node, ast.NameNode), 'Node is not a NameNode.'
 
         new_name = node.name
         new_entry = self._Entry(node, self.cur_scope)
@@ -184,10 +185,13 @@ class SymbolTable:
             entry = self._find_identifier_in_current_scope(new_name)
             if entry is not None:
                 self.logger.error(
-                    # FIXME: Meaningful line?
-                    "error: Duplicate identifier: %s",
-                    node.name
-                    # TODO: Show line of previous declaration
+                    "%d:%d: error: Redefining identifier '%s' in same scope"
+                    "\tPrevious definition: %d:%d",
+                    node.lineno,
+                    node.lexpos,
+                    node.name,
+                    entry.node.lineno,
+                    entry.node.lexpos
                 )
                 # TODO: Raise some kind of exception here.
 

--- a/compiler/symbol.py
+++ b/compiler/symbol.py
@@ -12,19 +12,26 @@
 
 from collections import defaultdict
 
+from compiler import ast
 
 class Entry:
-    """An entry of the symbol table. It knows which scope it's in."""
-    identifier = None
+    """An entry of the symbol table."""
+    # Reference to the ast node that the entry represents.
+    # The node should contain the lineno and lexpos attributes.
+    node = None
+
+    # Reference to the symbol table scope containing the entry.
+    # Used for fast lookup and sanity-checking.
     scope = None
 
-    lexpos = None
-    lineno = None
+    @property
+    def identifier(self):
+        return self.node.name
 
-    def __init__(self, identifier, scope):
-        self.identifier = identifier
+    def __init__(self, node, scope):
+        """Create a new symbol table entry from a NameNode."""
+        self.node = node
         self.scope = scope
-        # TODO: Initialize lineno and lexpos
 
 
 class Scope:
@@ -61,7 +68,8 @@ class SymbolTable:
 
     def _insert_library_symbols(self):
         """Open a new scope populated with the library namespace."""
-        lib_namespace = []  # TODO: Dump library namespace here
+        # TODO: Dump library namespace here as a tuple of virtual AST nodes.
+        lib_namespace = tuple()
 
         lib_scope = Scope(
             entries=[],
@@ -69,8 +77,8 @@ class SymbolTable:
             nesting=self.nesting
         )
 
-        for identifier in lib_namespace:
-            entry = Entry(identifier, lib_scope)
+        for node in lib_namespace:
+            entry = Entry(node, lib_scope)
             lib_scope.entries.append(entry)
 
         self._push_scope(lib_scope)

--- a/compiler/symbol.py
+++ b/compiler/symbol.py
@@ -184,10 +184,10 @@ class SymbolTable:
             return None
         return entry
 
-    def insert_symbol(self, node, guard=False):
+    def insert_symbol(self, node):
         """
         Insert a new NameNode in the current scope.
-        If 'guard' is True, alert if an alias is already present.
+        Alert if an alias is already present in same scope.
         """
         assert self.cur_scope, 'No scope to insert into.'
         assert isinstance(node, ast.NameNode), 'Node is not a NameNode.'
@@ -195,19 +195,18 @@ class SymbolTable:
         new_name = node.name
         new_entry = self._Entry(node, self.cur_scope)
 
-        if guard:
-            entry = self._find_identifier_in_current_scope(new_name)
-            if entry is not None:
-                self.logger.error(
-                    "%d:%d: error: Redefining identifier '%s' in same scope"
-                    "\tPrevious definition: %d:%d",
-                    node.lineno,
-                    node.lexpos,
-                    node.name,
-                    entry.node.lineno,
-                    entry.node.lexpos
-                )
-                # TODO: Raise some kind of exception here.
+        entry = self._find_identifier_in_current_scope(new_name)
+        if entry is not None:
+            self.logger.error(
+                "%d:%d: error: Redefining identifier '%s' in same scope"
+                "\tPrevious definition: %d:%d",
+                node.lineno,
+                node.lexpos,
+                node.name,
+                entry.node.lineno,
+                entry.node.lexpos
+            )
+            # TODO: Raise some kind of exception here.
 
         self.hash_table[new_entry.identifier].append(new_entry)
         self.cur_scope.entries.append(new_entry)

--- a/compiler/symbol.py
+++ b/compiler/symbol.py
@@ -160,7 +160,7 @@ class SymbolTable:
         assert self.cur_scope, 'No scope to search.'
         try:
             entry = self._hash_table[ename][-1]
-        except (KeyError, IndexError):
+        except IndexError:
             # NOTE: Using defaultdict means KeyError never happens.
             return None
 

--- a/compiler/symbol.py
+++ b/compiler/symbol.py
@@ -33,6 +33,22 @@ class RedefIdentifierError(SymbolError):
         self.prev = prev
 
 
+class Scope:
+    """
+    A scope of the symbol table. Contains a list of entries,
+    knows its nesting level and can be optionally hidden from lookup.
+    """
+    entries = []
+    visible = True
+    nesting = None
+
+    def __init__(self, entries, visible, nesting):
+        """Make a new scope."""
+        self.entries = entries
+        self.visible = visible
+        self.nesting = nesting
+
+
 class SymbolTable:
     """A fully Pythonic symbol table for Llama."""
 
@@ -53,23 +69,6 @@ class SymbolTable:
             self.node = node
             self.scope = scope
 
-
-    class _Scope:
-        """
-        A scope of the symbol table. Contains a list of entries,
-        knows its nesting level and can be optionally hidden from lookup.
-        """
-        entries = []
-        visible = True
-        nesting = None
-
-        def __init__(self, entries, visible, nesting):
-            """Make a new scope."""
-            self.entries = entries
-            self.visible = visible
-            self.nesting = nesting
-
-
     _scopes = []
     nesting = 0       # Inv.: nesting == len(scopes)
     cur_scope = None  # Inv.: cur_scope == _scopes[-1] if _scopes else None
@@ -87,7 +86,7 @@ class SymbolTable:
         # TODO: Dump library namespace here as a tuple of virtual AST nodes.
         lib_namespace = tuple()
 
-        lib_scope = self._Scope(
+        lib_scope = Scope(
             entries=[],
             visible=True,
             nesting=self.nesting
@@ -118,7 +117,7 @@ class SymbolTable:
 
     def open_scope(self):
         """Open a new scope in the symbol table."""
-        new_scope = self._Scope(
+        new_scope = Scope(
             entries=[],
             visible=True,
             nesting=self.nesting + 1

--- a/tests/test_symbol.py
+++ b/tests/test_symbol.py
@@ -1,6 +1,6 @@
 import unittest
 
-from compiler import error, symbol
+from compiler import ast, error, symbol
 
 
 class TestSymbolTableAPI(unittest.TestCase):
@@ -14,3 +14,14 @@ class TestSymbolTableAPI(unittest.TestCase):
         symbol_table2 = symbol.SymbolTable(logger=logger)
 
         symbol_table2.should.have.property("logger").being(logger)
+
+    @staticmethod
+    def test_redef_identifier_error():
+        node = ast.GenidExpression("foo")
+        node.lineno, node.lexpos = 1, 2
+        prev = ast.GenidExpression("foo")
+        prev.lineno, prev.lexpos = 3, 4
+        exc = symbol.RedefIdentifierError(node, prev)
+        exc.should.be.a(symbol.SymbolError)
+        exc.should.have.property("node").being(node)
+        exc.should.have.property("prev").being(prev)

--- a/tests/test_symbol.py
+++ b/tests/test_symbol.py
@@ -1,0 +1,16 @@
+import unittest
+
+from compiler import error, symbol
+
+
+class TestSymbolTableAPI(unittest.TestCase):
+    """Test the API of the SymbolTable class."""
+
+    @staticmethod
+    def test_symboltable_init():
+        symbol_table1 = symbol.SymbolTable()
+
+        logger = error.LoggerMock()
+        symbol_table2 = symbol.SymbolTable(logger=logger)
+
+        symbol_table2.should.have.property("logger").being(logger)

--- a/tests/test_symbol.py
+++ b/tests/test_symbol.py
@@ -22,10 +22,11 @@ class TestSymbolTableAPI(unittest.TestCase):
         exc = symbol.RedefIdentifierError
         issubclass(exc, symbol.SymbolError).should.be.true
 
-    @staticmethod
-    def test_functionality():
+    def test_functionality(self):
         expr = ast.GenidExpression("foo")
+        expr.lineno, expr.lexpos = 1, 2
         param = ast.Param("foo")
+        param.lineno, param.lexpos = 3, 4
 
         table = symbol.SymbolTable()
         scope1 = table.open_scope()
@@ -40,8 +41,12 @@ class TestSymbolTableAPI(unittest.TestCase):
 
         table.lookup_symbol(ast.Param("bar")).should.be(None)
 
-        error2 = symbol.RedefIdentifierError
-        table.insert_symbol.when.called_with(param).should.throw(error2)
+        with self.assertRaises(symbol.RedefIdentifierError) as context:
+            table.insert_symbol(param)
+
+        exc = context.exception
+        exc.should.have.property("node").being(param)
+        exc.should.have.property("prev").being(expr)
 
         scope2 = table.open_scope()
         table.insert_symbol.when.called_with(param).shouldnt.throw(error1)

--- a/tests/test_symbol.py
+++ b/tests/test_symbol.py
@@ -1,6 +1,6 @@
 import unittest
 
-from compiler import ast, error, symbol
+from compiler import ast, symbol
 
 
 class TestSymbolTableAPI(unittest.TestCase):
@@ -8,12 +8,7 @@ class TestSymbolTableAPI(unittest.TestCase):
 
     @staticmethod
     def test_symboltable_init():
-        symbol_table1 = symbol.SymbolTable()
-
-        logger = error.LoggerMock()
-        symbol_table2 = symbol.SymbolTable(logger=logger)
-
-        symbol_table2.should.have.property("logger").being(logger)
+        symbol.SymbolTable()
 
     @staticmethod
     def test_redef_identifier_error():

--- a/tests/test_symbol.py
+++ b/tests/test_symbol.py
@@ -19,14 +19,8 @@ class TestSymbolTableAPI(unittest.TestCase):
 
     @staticmethod
     def test_redef_identifier_error():
-        node = ast.GenidExpression("foo")
-        node.lineno, node.lexpos = 1, 2
-        prev = ast.GenidExpression("foo")
-        prev.lineno, prev.lexpos = 3, 4
-        exc = symbol.RedefIdentifierError(node, prev)
-        exc.should.be.a(symbol.SymbolError)
-        exc.should.have.property("node").being(node)
-        exc.should.have.property("prev").being(prev)
+        exc = symbol.RedefIdentifierError
+        issubclass(exc, symbol.SymbolError).should.be.true
 
     @staticmethod
     def test_functionality():

--- a/tests/test_symbol.py
+++ b/tests/test_symbol.py
@@ -7,6 +7,13 @@ class TestSymbolTableAPI(unittest.TestCase):
     """Test the API of the SymbolTable class."""
 
     @staticmethod
+    def test_scope_init():
+        scope = symbol.Scope()
+        scope.should.have.property("entries").equal([])
+        scope.should.have.property("visible").equal(False)
+        scope.should.have.property("nesting").being(None)
+
+    @staticmethod
     def test_symboltable_init():
         symbol.SymbolTable()
 

--- a/tests/test_symbol.py
+++ b/tests/test_symbol.py
@@ -20,3 +20,38 @@ class TestSymbolTableAPI(unittest.TestCase):
         exc.should.be.a(symbol.SymbolError)
         exc.should.have.property("node").being(node)
         exc.should.have.property("prev").being(prev)
+
+    @staticmethod
+    def test_functionality():
+        expr = ast.GenidExpression("foo")
+        param = ast.Param("foo")
+
+        table = symbol.SymbolTable()
+        table.open_scope()
+
+        error1 = symbol.SymbolError
+        table.insert_symbol.when.called_with(expr).shouldnt.throw(error1)
+
+        table.lookup_symbol(expr).should.be(expr)
+
+        # Counter-intuitive, but this is what is needed.
+        table.lookup_symbol(param).should.be(expr)
+
+        table.lookup_symbol(ast.Param("bar")).should.be(None)
+
+        error2 = symbol.RedefIdentifierError(param, expr)
+        table.insert_symbol.when.called_with(param).should.throw(error2)
+
+        table.open_scope()
+        table.insert_symbol.when.called_with(param).shouldnt.throw(error1)
+
+        table.lookup_symbol(param).should.equal(param)
+        table.lookup_symbol(expr).should.equal(param)
+
+        table.open_scope()
+        table.lookup_symbol(expr, lookup_all=True).should.equal(param)
+        table.lookup_symbol(param, lookup_all=True).should.equal(param)
+
+        table.close_scope()
+        table.close_scope()
+        table.close_scope()

--- a/tests/test_symbol.py
+++ b/tests/test_symbol.py
@@ -33,7 +33,7 @@ class TestSymbolTableAPI(unittest.TestCase):
         table = symbol.SymbolTable()
 
         # Open a scope and define "foo".
-        scope1 = table.open_scope()
+        table.open_scope()
         error1 = symbol.SymbolError
         table.insert_symbol.when.called_with(expr).shouldnt.throw(error1)
 
@@ -48,7 +48,7 @@ class TestSymbolTableAPI(unittest.TestCase):
         table.find_live_def(ast.Param("bar")).should.be(None)
 
         # Check for scope effectiveness.
-        scope2a = table.open_scope()
+        table.open_scope()
         table.find_symbol_in_current_scope(expr).should.be(None)
         table.find_live_def(expr).should.be(expr)
         table.close_scope()

--- a/tests/test_symbol.py
+++ b/tests/test_symbol.py
@@ -8,10 +8,10 @@ class TestSymbolTableAPI(unittest.TestCase):
 
     @staticmethod
     def test_scope_init():
-        scope = symbol.Scope()
+        scope = symbol.Scope([], True, 1)
         scope.should.have.property("entries").equal([])
-        scope.should.have.property("visible").equal(False)
-        scope.should.have.property("nesting").being(None)
+        scope.should.have.property("visible").equal(True)
+        scope.should.have.property("nesting").being(1)
 
     @staticmethod
     def test_symboltable_init():
@@ -34,7 +34,7 @@ class TestSymbolTableAPI(unittest.TestCase):
         param = ast.Param("foo")
 
         table = symbol.SymbolTable()
-        table.open_scope()
+        scope1 = table.open_scope()
 
         error1 = symbol.SymbolError
         table.insert_symbol.when.called_with(expr).shouldnt.throw(error1)
@@ -46,18 +46,19 @@ class TestSymbolTableAPI(unittest.TestCase):
 
         table.lookup_symbol(ast.Param("bar")).should.be(None)
 
-        error2 = symbol.RedefIdentifierError(param, expr)
+        error2 = symbol.RedefIdentifierError
         table.insert_symbol.when.called_with(param).should.throw(error2)
 
-        table.open_scope()
+        scope2 = table.open_scope()
         table.insert_symbol.when.called_with(param).shouldnt.throw(error1)
 
         table.lookup_symbol(param).should.equal(param)
         table.lookup_symbol(expr).should.equal(param)
 
-        table.open_scope()
+        scope3 = table.open_scope()
         table.lookup_symbol(expr, lookup_all=True).should.equal(param)
-        table.lookup_symbol(param, lookup_all=True).should.equal(param)
+        scope2.visible = False
+        table.lookup_symbol(param, lookup_all=True).should.equal(expr)
 
         table.close_scope()
         table.close_scope()


### PR DESCRIPTION
## Motivation:

The compiler is built around the assumption that the AST carries detailed information about the code. Thus, there is little need for a complex `SymbolTable` with specialised classes for each `Entry` type. The main objective of this PR is to have the `SymbolTable` be as simple as possible. It should perform name disambiguation using existing AST nodes (packaged in a thin `Entry` wrapper for implementation purposes). It should signal errors using just exceptions and return values. It shouldn't (in principle) be necessary for code generation; def-use chains will have been already resolved by the time of codegen; stack frames should be designed on the AST. 
### AST:
- Attach a `NameNode` superclass to every node worth inserting to some
  kind of symbol table.
### Symbol:
- Major API redesign: Insert/Lookup AST nodes instead of identifiers.
- Redesign `Entry` as a thin wrapper around `ast.NameNode`s. Make it a private class of `SymbolTable`.
- Add lineinfo to error messages (using AST nodes).
- Add exception for reporting identifier redefinition.
- Rewrite `lookup_symbol`:
  - Drop useless `guard` parametre; always return None if the node is not found.
  - Assert correct nesting.
  - Inline `_find_name_in_current_scope`.
  - Correctly handle case where identifier is not present.
- Rewrite `insert_symbol`:
  - Create an `Entry` before inserting it.
  - Don't return anything.
  - Drop `guard` parametre; always raise an exception when identifier is redefined in same scope.
- Simplify `Scope` class.
- Drop `logger`; the semantic analyzer should notify the user of any errors caught.
- Make `hash_table` private as it should have always been.
- Make provisions for lib namespace initialization.
- Groom code.
### Symbol test:
- Add initial tests for `Scope` and `SymbolTable` APIs.
- Add initial functional tests for `SymbolTable`. Partly adresses #27.
