### PR TITLE
Replace pep8 with flake8. Strengthen static analysis. Check code on each build.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,15 +5,16 @@ SOURCEFILES=main.py ./compiler/*.py
 BINPATH=./bin
 TESTPATH=./tests/
 
-.PHONY: beauty clean cleanaux functionaltest prepare static test unittest
+.PHONY: check clean cleanaux functionaltest prepare test unittest
 
 all: clean prepare test
 
-beauty:
+check:
 	flake8 --ignore=E221 ./compiler/lex.py
 	flake8 --ignore=E501 ./compiler/parse.py
 	flake8 --exclude=lex.py,parse.py $(SOURCEFILES)
 	flake8 --exclude=__init__.py $(TESTPATH)/*.py
+	pylint -E $(SOURCEFILES)
 
 test: unittest functionaltest
 
@@ -22,9 +23,6 @@ unittest: $(BINPATH)/utest.sh
 
 functionaltest: $(BINPATH)/ftest.sh
 	$(BINPATH)/ftest.sh
-
-static:
-	pylint -E $(SOURCEFILES)
 
 prepare:
 	$(PYTHON) main.py $(PREPARE_FLAGS)

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ TESTPATH=./tests/
 all: clean prepare test
 
 beauty:
-	pep8 --ignore=E221 $(SOURCEFILES) $(TESTPATH)
+	flake8 --ignore=E221 $(SOURCEFILES) $(TESTPATH)
 
 test: unittest functionaltest
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PREPARE_FLAGS=--prepare -pd
 OPT=-OO
 SOURCEFILES=main.py ./compiler/*.py
 BINPATH=./bin
-TESTPATH=./tests/
+TESTPATH=./tests
 
 .PHONY: check clean cleanaux functionaltest prepare test unittest
 
@@ -14,7 +14,8 @@ check:
 	flake8 --ignore=E501 ./compiler/parse.py
 	flake8 --exclude=lex.py,parse.py $(SOURCEFILES)
 	flake8 --exclude=__init__.py $(TESTPATH)/*.py
-	pylint -E $(SOURCEFILES)
+	pylint -E --ignore=test_lexer.py $(SOURCEFILES) $(TESTPATH)
+	pylint -E -d E1101 $(TESTPATH)/test_lexer.py
 
 test: unittest functionaltest
 

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ TESTPATH=./tests
 
 .PHONY: check clean cleanaux functionaltest prepare test unittest
 
-all: clean prepare test
+all: clean prepare check test
 
 check:
 	flake8 --ignore=E221 ./compiler/lex.py

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,10 @@ TESTPATH=./tests/
 all: clean prepare test
 
 beauty:
-	flake8 --ignore=E221 $(SOURCEFILES) $(TESTPATH)
+	flake8 --ignore=E221 ./compiler/lex.py
+	flake8 --ignore=E501 ./compiler/parse.py
+	flake8 --exclude=lex.py,parse.py $(SOURCEFILES)
+	flake8 --exclude=__init__.py $(TESTPATH)/*.py
 
 test: unittest functionaltest
 

--- a/main.py
+++ b/main.py
@@ -151,7 +151,7 @@ def main():
     data = read_program(OPTS["input"])
 
     # Lex, parse and construct the AST.
-    ast = parser.parse(data=data, lexer=lexer)
+    parser.parse(data=data, lexer=lexer)
 
     # On lexing/parsing error, abort further compilation.
     if not (lexer.logger.success or parser.logger.success):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
+flake8>=2.2.3
 mock>=1.0.1
 nose>=1.3.3
-pep8>=1.5.6
 ply>=3.4
 pylint>=1.2.1
 six>=1.7.2

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -33,7 +33,7 @@ class TestLexerAPI(unittest.TestCase):
 
     @staticmethod
     def test_init():
-        lexer1 = lex.Lexer()
+        lex.Lexer()
 
         logger = error.LoggerMock()
         lexer2 = lex.Lexer(
@@ -64,13 +64,13 @@ class TestLexerAPI(unittest.TestCase):
         lexer = lex.Lexer()
         lexer.token.when.called.should.throw(Exception)
         lexer.input("foo")
-        t = lexer.token()
+        lexer.token()
 
     @staticmethod
     def test_iterator():
         lexer = lex.Lexer()
         lexer.input("foo")
-        i = iter(lexer)
+        iter(lexer)
         next(lexer)
 
     @staticmethod

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -433,7 +433,7 @@ class TestParser(unittest.TestCase, parser_db.ParserDB):
         start will fail.
         """
         p = parse.Parser(logger=error.LoggerMock(), start=start)
-        _ = p.parse(expr)
+        p.parse(expr)
         p.logger.success.should.be.false
 
     def test_precedence_new_bang(self):

--- a/tests/test_type.py
+++ b/tests/test_type.py
@@ -62,6 +62,7 @@ class TestBase(unittest.TestCase, parser_db.ParserDB):
         node.should.have.property("lexpos")
         node.lexpos.shouldnt.be(None)
 
+
 class TestTable(TestBase):
     """Test the Table's processing of type definitions."""
 
@@ -84,7 +85,6 @@ class TestTable(TestBase):
         for case in right_testcases:
             tree = self._parse(case, "typedef")
             proc.when.called_with(tree).shouldnt.throw(type.BadTypeDefError)
-
 
     def test_type_process_wrong(self):
         wrong_testcases = (


### PR DESCRIPTION
### Requirements:
- Replace `pep8` package with `flake8`.
### Makefile:
- Use `flake8` to perform style checks.
- `flake8` and `pylint` now target testfiles as well.
- Refine checking so that known deviations aren't flagged.
- Combine `static` and `beauty` targets into `check`.
- Perform `check` on each build.
### Main + Tests:
- Fix `flake8` warnings.
