### PR TITLE
Install coveralls and cleanup build.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.swp
 aux*.py
+.coverage
 lextab.py
 parsetab.py
 parser.out

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: python
+
 python:
-  - "3.3"
   - "3.4"
-# command to install dependencies
+
 install:
   - "pip install -r requirements.txt"
-# command to run tests
-script: make
+
+script:
+    - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,6 @@ install:
 
 script:
     - make
+
+after_success:
+    - coveralls

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,6 @@ cleanaux:
 	$(RM) aux*.py
 
 cleanmain:
-	$(RM) lextab.py parsetab.py parser.out
+	$(RM) lextab.py parsetab.py parser.out .coverage
 
 clean: cleanaux cleanmain

--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,8 @@ check:
 
 test: unittest functionaltest
 
-unittest: $(BINPATH)/utest.sh
-	$(BINPATH)/utest.sh
+unittest:
+	nosetests --with-coverage --cover-package=compiler --cover-inclusive
 
 functionaltest: $(BINPATH)/ftest.sh
 	$(BINPATH)/ftest.sh

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A llama implementation in Python.
 * [pylint](http://www.pylint.org/): Static analysis of Python code.
 * [nose](https://pypi.python.org/pypi/nose/): Easy test discovery.
 * [sure](http://falcao.it/sure/): DSL for human-readable assertions in Python.
-* [pep8](https://pypi.python.org/pypi/pep8): Python style guide checker.
+* [flake8](https://pypi.python.org/pypi/flake8): Python style checker.
 
 ## License
 llama is released under the [MIT License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # llama 
 
 [![Build Status](https://travis-ci.org/dionyziz/llama.svg?branch=master)](https://travis-ci.org/dionyziz/llama)
+[![Coverage Status](https://img.shields.io/coveralls/dionyziz/llama.svg)](https://coveralls.io/r/dionyziz/llama)
 
 A llama implementation in Python.
 

--- a/bin/utest.sh
+++ b/bin/utest.sh
@@ -1,9 +1,0 @@
-#!/bin/sh
-
-TEST_PATH=tests
-
-for i in `find tests -iname 'test_*.py'`; do
-    echo ".: Unit Testing: $i"
-    nosetests $i || exit 2
-    echo
-done

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+coverage
 flake8>=2.2.3
 mock>=1.0.1
 nose>=1.3.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,6 @@ mock>=1.0.1
 nose>=1.3.3
 ply>=3.4
 pylint>=1.2.1
+python-coveralls
 six>=1.7.2
 sure>=1.2.7


### PR DESCRIPTION
### Changelog
- Drop support for Python 3.3
- Install test coverage reporting via [coveralls.io](https://coveralls.io/).
