### PR TITLE
Install stricter pylinting

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -34,7 +34,7 @@ load-plugins=
 # classes checker, but have no Warning level messages displayed,
 # use "--disable=all --enable=classes --disable=W"
 enable=E,W,R,C,F
-disable=W0106,W0223,W0231,W0511,W0613,W0621,W0622,R0201,R0903,R0904,R0913,R0923,C0103,C0111,C0330
+disable=W0223,W0231,W0511,W0613,W0621,W0622,R0201,R0903,R0904,R0913,R0923,C0103,C0111,C0330
 
 
 [REPORTS]

--- a/.pylintrc
+++ b/.pylintrc
@@ -34,7 +34,7 @@ load-plugins=
 # classes checker, but have no Warning level messages displayed,
 # use "--disable=all --enable=classes --disable=W"
 enable=E,W,R,C,F
-disable=E1101,W0104,W0106,W0223,W0231,W0511,W0613,W0621,W0622,R0201,R0903,R0904,R0913,R0923,C0103,C0111,C0326,C0330
+disable=W0104,W0106,W0223,W0231,W0511,W0613,W0621,W0622,R0201,R0903,R0904,R0913,R0923,C0103,C0111,C0326,C0330
 
 
 [REPORTS]

--- a/.pylintrc
+++ b/.pylintrc
@@ -34,7 +34,7 @@ load-plugins=
 # classes checker, but have no Warning level messages displayed,
 # use "--disable=all --enable=classes --disable=W"
 enable=E,W,R,C,F
-disable=W0104,W0106,W0223,W0231,W0511,W0613,W0621,W0622,R0201,R0903,R0904,R0913,R0923,C0103,C0111,C0326,C0330
+disable=W0104,W0106,W0223,W0231,W0511,W0613,W0621,W0622,R0201,R0903,R0904,R0913,R0923,C0103,C0111,C0330
 
 
 [REPORTS]

--- a/.pylintrc
+++ b/.pylintrc
@@ -34,7 +34,7 @@ load-plugins=
 # classes checker, but have no Warning level messages displayed,
 # use "--disable=all --enable=classes --disable=W"
 enable=E,W,R,C,F
-disable=E1101,W0104,W0106,W0223,W0231,W0511,W0613,W0621,W0622,R0201,R0903,R0904,R0913,R0923,C0103,C0111,C0326,C0330,F0401
+disable=E1101,W0104,W0106,W0223,W0231,W0511,W0613,W0621,W0622,R0201,R0903,R0904,R0913,R0923,C0103,C0111,C0326,C0330
 
 
 [REPORTS]

--- a/.pylintrc
+++ b/.pylintrc
@@ -34,7 +34,7 @@ load-plugins=
 # classes checker, but have no Warning level messages displayed,
 # use "--disable=all --enable=classes --disable=W"
 enable=E,W,R,C,F
-disable=W0104,W0106,W0223,W0231,W0511,W0613,W0621,W0622,R0201,R0903,R0904,R0913,R0923,C0103,C0111,C0330
+disable=W0106,W0223,W0231,W0511,W0613,W0621,W0622,R0201,R0903,R0904,R0913,R0923,C0103,C0111,C0330
 
 
 [REPORTS]

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,326 @@
+[MASTER]
+
+# Specify a configuration file.
+#rcfile=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Profiled execution.
+profile=no
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=
+
+# Pickle collected data for later comparisons.
+persistent=no
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+
+[MESSAGES CONTROL]
+
+# Enable/Disable the message, report, category or checker with the given id(s).
+# You can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once).
+# You can also use "--disable=all" to disable everything first and then reenable
+# specific checks. For example, if you want to run only the similarities checker,
+# you can use "--disable=all --enable=similarities". If you want to run only the
+# classes checker, but have no Warning level messages displayed,
+# use "--disable=all --enable=classes --disable=W"
+enable=E,W,R,C,F
+disable=E1101,W0104,W0106,W0223,W0231,W0511,W0613,W0621,W0622,R0201,R0903,R0904,R0913,R0923,C0103,C0111,C0326,C0330,F0401
+
+
+[REPORTS]
+
+# Set the output format. Available formats are text, parseable, colorized, msvs
+# (visual studio) and html. You can also give a reporter class, eg
+# mypackage.mymodule.MyReporterClass.
+output-format=colorized
+
+# Put messages in a separate file for each module / package specified on the
+# command line instead of printing them on stdout. Reports (if any) will be
+# written in a file name "pylint_global.[txt|html]".
+files-output=no
+
+# Tells whether to display a full report or only the messages
+reports=no
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Add a comment according to your evaluation note. This is used by the global
+# evaluation report (RP0004).
+comment=no
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details
+msg-template={path}:{line:3d}: [{C}:{symbol}] -- {msg}
+
+
+[SIMILARITIES]
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+
+[TYPECHECK]
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis
+ignored-modules=
+
+# List of classes names for which member attributes should not be checked
+# (useful for classes with attributes dynamically set).
+ignored-classes=SQLObject
+
+# When zope mode is activated, add a predefined set of Zope acquired attributes
+# to generated-members.
+zope=no
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E0201 when accessed. Python regular
+# expressions are accepted.
+generated-members=REQUEST,acl_users,aq_parent
+
+
+[FORMAT]
+
+# Maximum number of characters on a single line.
+max-line-length=94
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+# List of optional constructs for which whitespace checking is disabled
+no-space-check=trailing-comma,dict-separator
+
+# Maximum number of lines in a module
+max-module-lines=1000
+
+# String used as indentation unit. This is usually " " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Number of spaces of indent required inside a hanging or continued line.
+indent-after-paren=4
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,XXX,TODO
+
+
+[LOGGING]
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format
+logging-modules=logging
+
+
+[BASIC]
+
+# Required attributes for module, separated by a comma
+required-attributes=
+
+# List of builtins function names that should not be used, separated by a comma
+bad-functions=map,filter,apply,input,file
+
+# Good variable names which should always be accepted, separated by a comma
+good-names=i,j,k,ex,Run,_
+
+# Bad variable names which should always be refused, separated by a comma
+bad-names=foo,bar,baz,koko,lala,toto,tutu,tata
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Include a hint for the correct naming format with invalid-name
+include-naming-hint=no
+
+# Regular expression matching correct function names
+function-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for function names
+function-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct variable names
+variable-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for variable names
+variable-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct constant names
+const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+
+# Naming hint for constant names
+const-name-hint=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+
+# Regular expression matching correct attribute names
+attr-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for attribute names
+attr-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct argument names
+argument-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for argument names
+argument-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct class attribute names
+class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
+
+# Naming hint for class attribute names
+class-attribute-name-hint=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
+
+# Regular expression matching correct inline iteration names
+inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
+
+# Naming hint for inline iteration names
+inlinevar-name-hint=[A-Za-z_][A-Za-z0-9_]*$
+
+# Regular expression matching correct class names
+class-rgx=[A-Z_][a-zA-Z0-9]+$
+
+# Naming hint for class names
+class-name-hint=[A-Z_][a-zA-Z0-9]+$
+
+# Regular expression matching correct module names
+module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+
+# Naming hint for module names
+module-name-hint=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+
+# Regular expression matching correct method names
+method-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for method names
+method-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=__.*__
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+
+[VARIABLES]
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# A regular expression matching the name of dummy variables (i.e. expectedly
+# not used).
+dummy-variables-rgx=_$|dummy
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid to define new builtins when possible.
+additional-builtins=
+
+
+[CLASSES]
+
+# List of interface methods to ignore, separated by a comma. This is used for
+# instance to not check methods defines in Zope's Interface base class.
+ignore-iface-methods=isImplementedBy,deferred,extends,names,namesAndDescriptions,queryDescriptionFor,getBases,getDescriptionFor,getDoc,getName,getTaggedValue,getTaggedValueTags,isEqualOrExtendedBy,setTaggedValue,isImplementedByInstancesOf,adaptWith,is_implemented_by
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,__new__,setUp
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=mcs
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method
+max-args=5
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore
+ignored-argument-names=_.*
+
+# Maximum number of locals for function / method body
+max-locals=15
+
+# Maximum number of return / yield for function / method body
+max-returns=6
+
+# Maximum number of branch for function / method body
+max-branches=12
+
+# Maximum number of statements in function / method body
+max-statements=50
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+
+[IMPORTS]
+
+# Deprecated modules which should not be used, separated by a comma
+deprecated-modules=regsub,TERMIOS,Bastion,rexec
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled)
+import-graph=
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled)
+ext-import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled)
+int-import-graph=
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "Exception"
+overgeneral-exceptions=Exception

--- a/Makefile
+++ b/Makefile
@@ -5,17 +5,20 @@ SOURCEFILES=main.py ./compiler/*.py
 BINPATH=./bin
 TESTPATH=./tests
 
-.PHONY: check clean cleanaux functionaltest prepare test unittest
+.PHONY: check clean cleanaux flake8check functionaltest prepare pylintcheck test unittest
 
 all: clean prepare check test
 
-check:
+pylintcheck:
+	pylint --rcfile .pylintrc $(SOURCEFILES) $(TESTPATH)
+
+flake8check:
 	flake8 --ignore=E221 ./compiler/lex.py
 	flake8 --ignore=E501 ./compiler/parse.py
 	flake8 --exclude=lex.py,parse.py $(SOURCEFILES)
 	flake8 --exclude=__init__.py $(TESTPATH)/*.py
-	pylint -E --ignore=test_lexer.py $(SOURCEFILES) $(TESTPATH)
-	pylint -E -d E1101 $(TESTPATH)/test_lexer.py
+
+check: flake8check pylintcheck
 
 test: unittest functionaltest
 

--- a/compiler/lex.py
+++ b/compiler/lex.py
@@ -314,6 +314,7 @@ class _LexerFactory:
 
     # == LEXING OF TOKENS CARRYING NO VALUE ==
 
+    # pylint: disable=bad-whitespace
     # Integer operators
     t_PLUS      = r'\+'
     t_MINUS     = r'-'

--- a/tests/test_ast.py
+++ b/tests/test_ast.py
@@ -3,6 +3,8 @@ import unittest
 
 from compiler import ast, parse
 
+# pylint: disable=no-member
+
 
 class TestAST(unittest.TestCase):
 

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -3,6 +3,8 @@ import unittest
 
 from compiler import error, lex
 
+# pylint: disable=no-member
+
 
 class TestModuleAPI(unittest.TestCase):
     """Test the API of the lex module."""

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -4,6 +4,7 @@ import unittest
 from compiler import error, lex
 
 # pylint: disable=no-member
+# pylint: disable=pointless-statement
 
 
 class TestModuleAPI(unittest.TestCase):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -64,7 +64,7 @@ class TestParserRules(unittest.TestCase):
         """
         p = parse.Parser(logger=error.LoggerMock(), start=start)
         p.parse(expr)
-        p.logger.success.should.be.false
+        p.logger.success.should.be.false  # pylint: disable=pointless-statement
 
     def test_empty_program(self):
         parse.quiet_parse("").should.equal(ast.Program([]))

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2,6 +2,8 @@ import unittest
 
 from compiler import ast, error, lex, parse
 
+# pylint: disable=no-member
+
 
 class TestModuleAPI(unittest.TestCase):
     """Test the API of the parse module."""

--- a/tests/test_symbol.py
+++ b/tests/test_symbol.py
@@ -2,6 +2,8 @@ import unittest
 
 from compiler import ast, symbol
 
+# pylint: disable=no-member
+
 
 class TestSymbolTableAPI(unittest.TestCase):
     """Test the API of the SymbolTable class."""

--- a/tests/test_symbol.py
+++ b/tests/test_symbol.py
@@ -19,10 +19,9 @@ class TestSymbolTableAPI(unittest.TestCase):
     def test_symboltable_init():
         symbol.SymbolTable()
 
-    @staticmethod
-    def test_redef_identifier_error():
+    def test_redef_identifier_error(self):
         exc = symbol.RedefIdentifierError
-        issubclass(exc, symbol.SymbolError).should.be.true
+        self.assertTrue(issubclass(exc, symbol.SymbolError))
 
     def test_functionality(self):
 

--- a/tests/test_type.py
+++ b/tests/test_type.py
@@ -8,48 +8,40 @@ from compiler import ast, parse, type
 class TestTypeAPI(unittest.TestCase):
     """Test the API of the type module."""
 
-    @staticmethod
-    def test_is_array():
-        type.is_array(ast.Array(ast.Int())).should.be.true
+    def test_is_array(self):
+        self.assertTrue(type.is_array(ast.Array(ast.Int())))
 
-    @staticmethod
-    def test_array_of_array_error():
+    def test_array_of_array_error(self):
         exc = type.ArrayOfArrayError
-        issubclass(exc, type.InvalidTypeError).should.be.true
+        self.assertTrue(issubclass(exc, type.InvalidTypeError))
 
-    @staticmethod
-    def test_array_return_error():
+    def test_array_return_error(self):
         exc = type.ArrayReturnError
-        issubclass(exc, type.InvalidTypeError).should.be.true
+        self.assertTrue(issubclass(exc, type.InvalidTypeError))
 
-    @staticmethod
-    def test_ref_of_array_error():
+    def test_ref_of_array_error(self):
         exc = type.RefOfArrayError
-        issubclass(exc, type.InvalidTypeError).should.be.true
+        self.assertTrue(issubclass(exc, type.InvalidTypeError))
 
     @staticmethod
     def test_validate():
         type.validate(ast.Int())
 
-    @staticmethod
-    def test_redef_builtin_type_error():
+    def test_redef_builtin_type_error(self):
         exc = type.RedefBuiltinTypeError
-        issubclass(exc, type.BadTypeDefError).should.be.true
+        self.assertTrue(issubclass(exc, type.BadTypeDefError))
 
-    @staticmethod
-    def test_redef_constructor_error():
+    def test_redef_constructor_error(self):
         exc = type.RedefConstructorError
-        issubclass(exc, type.BadTypeDefError).should.be.true
+        self.assertTrue(issubclass(exc, type.BadTypeDefError))
 
-    @staticmethod
-    def test_redef_user_type_error():
+    def test_redef_user_type_error(self):
         exc = type.RedefUserTypeError
-        issubclass(exc, type.BadTypeDefError).should.be.true
+        self.assertTrue(issubclass(exc, type.BadTypeDefError))
 
-    @staticmethod
-    def test_undef_type_error():
+    def test_undef_type_error(self):
         exc = type.UndefTypeError
-        issubclass(exc, type.BadTypeDefError).should.be.true
+        self.assertTrue(issubclass(exc, type.BadTypeDefError))
 
     @staticmethod
     def test_table_init():
@@ -152,7 +144,7 @@ class TestValidating(TestBase):
 
     def test_is_array(self):
         for typecon in ast.builtin_types_map.values():
-            type.is_array(typecon()).should.be.false
+            self.assertFalse(type.is_array(typecon()))
 
         right_testcases = (
             "array of int",
@@ -162,7 +154,7 @@ class TestValidating(TestBase):
 
         for case in right_testcases:
             tree = parse.quiet_parse(case, "type")
-            type.is_array(tree).should.be.true
+            self.assertTrue(type.is_array(tree))
 
         wrong_testcases = (
             "foo",
@@ -172,7 +164,7 @@ class TestValidating(TestBase):
 
         for case in wrong_testcases:
             tree = parse.quiet_parse(case, "type")
-            type.is_array(tree).should.be.false
+            self.assertFalse(type.is_array(tree))
 
     def test_validate(self):
         proc = type.validate

--- a/tests/test_type.py
+++ b/tests/test_type.py
@@ -2,6 +2,8 @@ import unittest
 
 from compiler import ast, parse, type
 
+# pylint: disable=no-member
+
 
 class TestTypeAPI(unittest.TestCase):
     """Test the API of the type module."""


### PR DESCRIPTION
### Changelog
- Systematize the use of `pylint` via a configuration file.
- Allow `pylint` to emit Warnings, Fatals, Conventions and Refactors.
- Explicitly suppress false signals.
- Replace some `sure` tests with casual `unittest` tests.
